### PR TITLE
Gardening: Update piracy/exe verification message

### DIFF
--- a/AppUI/Resources/StringResources.xaml
+++ b/AppUI/Resources/StringResources.xaml
@@ -737,7 +737,7 @@ Once done, do close the game and the launcher, and finally retry to click Play h
     <system:String x:Key="FileNotFoundAborting">file not found. Aborting ...</system:String>
     <system:String x:Key="Ff8ExeNotFoundYouMayNeedToConfigure">FF8.exe not found. You may need to configure J8 using the Settings>General Settings menu.</system:String>
     <system:String x:Key="VerifyingInstalledGameIsCompatible">Verifying installed game is compatible ...</system:String>
-    <system:String x:Key="ErrorCodeYarr">Error code: YARR! Unable to continue. This copy of FF8 appears to be pirated. Please purchase a genuine copy of the game. If this copy is genuine, please ask for help on the Qhimm forums.</system:String>
+    <system:String x:Key="ErrorCodeYarr">ODINE: Zis iz a strange file... seemz to bee corrupted by dee zorzeress! Use Steam's "Verify my files" tool or reinstall from CD to fix.</system:String>
     <system:String x:Key="VerifyingGameIsNotInstalledInProtectedFolder">Verifying game is not installed in a System/Protected folder ...</system:String>
 
     <system:String x:Key="Ff8IsCurrentlyInstalledInASystemFolder" xml:space="preserve">FF8 is currently installed in a System folder which can cause mods not to work. It is recommended you install it at C:\Games\Final Fantasy VIII


### PR DESCRIPTION
We haven't had a true pirate to make fun of in Discord for a very long time, but altered/corrupt EXE files show up fairly frequently.  Adjust the message to better reflect this.