### PR TITLE
AppUI: Fix NullReferenceException when InnerException is null

### DIFF
--- a/AppUI/ViewModels/CatalogViewModel.cs
+++ b/AppUI/ViewModels/CatalogViewModel.cs
@@ -553,7 +553,7 @@ namespace AppUI.ViewModels
                                 catch (Exception ex)
                                 {
                                     sub.FailureCount++;
-                                    Sys.Message(new WMessage() { Text = $"{ResourceHelper.Get(StringKey.FailedToLoadSubscription)} {subUrl}: {ex.Message} {ex.InnerException.Message}", LoggedException = ex });
+                                    Sys.Message(new WMessage() { Text = $"{ResourceHelper.Get(StringKey.FailedToLoadSubscription)} {subUrl}: {ex.Message} {ex.InnerException?.Message}", LoggedException = ex });
                                 }
                                 finally
                                 {


### PR DESCRIPTION
Port of tsunamods-codes/7th-Heaven#367.

## Summary

When loading a catalog subscription fails, the error handler at `CatalogViewModel.cs:556` accesses `ex.InnerException.Message` without checking if `InnerException` is null. Since `InnerException` is often null, this throws a secondary `NullReferenceException` in the error handler itself, masking the original error.

## Fix

Changed `ex.InnerException.Message` to `ex.InnerException?.Message` (null-conditional operator) so the message is simply omitted when there is no inner exception.