### PR TITLE
Common: Add .gitattributes to enforce CRLF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Normalize line endings to CRLF on checkout (Windows project)
+* text=auto eol=crlf
+
+# Explicitly binary — no line ending conversion
+*.png binary
+*.tga binary
+*.ico binary
+*.gif binary
+*.exe binary
+*.dll binary
+*.sys binary
+*.ogg binary
+*.cat binary
+*.var binary


### PR DESCRIPTION
## Summary

- Adds `.gitattributes` to normalize line endings to CRLF on checkout
- 92% of tracked text files already use CRLF — this enforces it consistently
- Marks known binary types (`.png`, `.dll`, `.exe`, `.ico`, etc.) explicitly so git never attempts line ending conversion on them

## Motivation

Contributors working across Linux and Windows environments were introducing
mixed LF/CRLF noise into diffs (e.g. the `SomethingWentWrongWhileDisablingDEP`
line in #77). This prevents that from happening going forward.

## Test plan

- [ ] Clone fresh on Windows — text files should have CRLF
- [ ] Clone fresh on Linux — text files should still have CRLF (enforced by `eol=crlf`)
- [ ] Verify binary files (`.png`, `.dll`, etc.) are unchanged after re-checkout