### PR TITLE
Add Simplified Chinese language option for Junction VIII

### DIFF
--- a/AppCore/StringKey.cs
+++ b/AppCore/StringKey.cs
@@ -657,6 +657,7 @@
         SomethingWentWrongWhileDisablingDEP,
         App4GBPatchRequired,
         App4GBPatchApplied,
-        ModShaders
+        ModShaders,
+        SimplifiedChinese
     }
 }

--- a/AppUI/App.xaml.cs
+++ b/AppUI/App.xaml.cs
@@ -414,6 +414,9 @@ namespace AppUI
                     case "it":
                         dict.Source = new Uri("Resources\\Languages\\StringResources.it.xaml", UriKind.Relative);
                         break;
+                    case "zh":
+                        dict.Source = new Uri("Resources\\Languages\\StringResources.zh.xaml", UriKind.Relative);
+                        break;
                     default:
                         dict.Source = new Uri("Resources\\StringResources.xaml", UriKind.Relative);
                         cultureCode = "en";

--- a/AppUI/AppUI.csproj
+++ b/AppUI/AppUI.csproj
@@ -203,6 +203,9 @@
     <None Update="Resources\Languages\J8_GameDriver_UI.ja.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Resources\Languages\J8_GameDriver_UI.zh.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Resources\Licenses\icons_license.txt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/AppUI/Resources/Languages/J8_GameDriver_UI.zh.xml
+++ b/AppUI/Resources/Languages/J8_GameDriver_UI.zh.xml
@@ -1,0 +1,311 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ConfigSpec xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+
+  <!-- GRAPHICS TAB -->
+  <Setting xsi:type="DropDown">
+    <Group>画面</Group>
+    <Name>图形 API</Name>
+    <Description>选择游戏的软件渲染方式。{0}如果遇到游戏闪退、场景黑屏等问题，可依次尝试每个选项，直到游戏正常。{0}DirectX 11是最稳定的选项。AMD显卡不建议选择OpenGL选项。</Description>
+    <DefaultValue>renderer_backend = 0</DefaultValue>
+    <Option>
+      <Text>Auto</Text>
+      <Settings>renderer_backend = 0</Settings>
+    </Option>
+    <Option>
+      <Text>OpenGL</Text>
+      <Settings>renderer_backend = 1</Settings>
+    </Option>
+    <Option>
+      <Text>DirectX 11</Text>
+      <Settings>renderer_backend = 3</Settings>
+    </Option>
+    <Option>
+      <Text>DirectX 12</Text>
+      <Settings>renderer_backend = 4</Settings>
+    </Option>
+    <Option>
+      <Text>Vulkan</Text>
+      <Settings>renderer_backend = 5</Settings>
+    </Option>
+  </Setting>
+
+  <Setting xsi:type="DropDown">
+    <Group>画面</Group>
+    <Name>显示器</Name>
+    <Description>选择游戏运行时的画面投放到哪个显示器上。仅在你的电脑连接了多台显示器的情况下可选。</Description>
+    <DefaultValue>display_index = -1</DefaultValue>
+    <Option>
+      <Text>主显示器</Text>
+      <Settings>display_index = -1</Settings>
+    </Option>
+  </Setting>
+
+  <Setting xsi:type="DropDown">
+    <Group>画面</Group>
+    <Name>分辨率</Name>
+    <Description>设置游戏窗口大小。仅影响窗口模式的分辨率，不影响全屏模式。{0}全屏模式会自动使用当前桌面分辨率。{0}Auto选项会自动使用游戏默认窗口分辨率。</Description>
+    <DefaultValue>window_size_x = 0,window_size_y = 0</DefaultValue>
+    <Option>
+      <Text>自动</Text>
+      <Settings>window_size_x = 0,window_size_y = 0</Settings>
+    </Option>
+  </Setting>
+
+  <Setting xsi:type="DropDown">
+    <Group>画面</Group>
+    <Name>窗口/全屏模式</Name>
+    <Description>按照你的需求，选择窗口/全屏/无边框窗口模式。</Description>
+    <DefaultValue>fullscreen = false,borderless = false</DefaultValue>
+    <Option>
+      <Text>窗口</Text>
+      <Settings>fullscreen = false,borderless = false</Settings>
+    </Option>
+    <Option>
+      <Text>全屏</Text>
+      <Settings>fullscreen = true,borderless = false</Settings>
+    </Option>
+    <Option>
+      <Text>无边框</Text>
+      <Settings>fullscreen = false,borderless = true</Settings>
+    </Option>
+  </Setting>
+
+  <Setting xsi:type="DropDown">
+    <Group>画面</Group>
+    <Name>画面比例</Name>
+    <Description>设置游戏画面的宽高比。{0}选择与你的显示器匹配的比例，否则画面边缘会出现黑边，或画面竖向拉长。</Description>
+    <DefaultValue>aspect_ratio = 0</DefaultValue>
+    <Option>
+      <Text>原生 (4:3)</Text>
+      <Settings>aspect_ratio = 0</Settings>
+    </Option>
+    <Option>
+      <Text>拉伸画面</Text>
+      <Settings>aspect_ratio = 1</Settings>
+    </Option>
+	<Option>
+		<Text>宽屏 (16:9)</Text>
+		<Settings>aspect_ratio = 2</Settings>
+	</Option>
+	<Option>
+		<Text>宽屏 (16:10)</Text>
+		<Settings>aspect_ratio = 3</Settings>
+	</Option>
+  </Setting>
+
+  <Setting xsi:type="DropDown">
+    <Group>画面</Group>
+    <Name>抗锯齿</Name>
+    <Description>减少锯齿边缘，提高图像质量。{0}考验电脑硬件配置，可能会使游戏卡顿。</Description>
+    <DefaultValue>enable_antialiasing = 0</DefaultValue>
+    <Option>
+      <Text>关闭</Text>
+      <Settings>enable_antialiasing = 0</Settings>
+    </Option>
+    <Option>
+      <Text>2x MSAA</Text>
+      <Settings>enable_antialiasing = 2</Settings>
+    </Option>
+    <Option>
+      <Text>4x MSAA</Text>
+      <Settings>enable_antialiasing = 4</Settings>
+    </Option>
+  </Setting>
+
+  <Setting xsi:type="Checkbox">
+    <Group>画面</Group>
+    <Name>各向异性过滤</Name>
+    <Description>给高分辨率贴图加上滤镜，生成更清晰的图像。{0}占用更多系统内存。</Description>
+    <DefaultValue>enable_anisotropic = true</DefaultValue>
+    <TrueSetting>enable_anisotropic = true</TrueSetting>
+    <FalseSetting>enable_anisotropic = false</FalseSetting>
+  </Setting>
+
+  <Setting xsi:type="Checkbox">
+    <Group>画面</Group>
+    <Name>垂直同步</Name>
+    <Description>将游戏帧率与你的显示器刷新率同步。如果遇到屏幕撕裂问题，请开启。{0}可能会影响60帧模式。{0}*如果你想使用【游戏变速】功能，请关闭垂直同步。</Description>
+    <DefaultValue>enable_vsync = true</DefaultValue>
+    <TrueSetting>enable_vsync = true</TrueSetting>
+    <FalseSetting>enable_vsync = false</FalseSetting>
+  </Setting>
+
+  <Setting xsi:type="Checkbox">
+    <Group>画面</Group>
+    <Name>NTSC-J 色域模式</Name>
+    <Description>模拟90年代日本电视机的色域（FF8最初的设计标准），使画面色彩更丰富。同时影响菜单栏背景色。</Description>
+    <DefaultValue>enable_ntscj_gamut_mode = false</DefaultValue>
+    <TrueSetting>enable_ntscj_gamut_mode = true</TrueSetting>
+    <FalseSetting>enable_ntscj_gamut_mode = false</FalseSetting>
+  </Setting>
+
+  <!-- CONTROLS TAB -->
+  <Setting xsi:type="Checkbox">
+    <Group>控制</Group>
+    <Name>使用手柄按键图标</Name>
+    <Description>使用手柄按键的图标贴图来替代 "B1"、"B2" 等文字。默认使用游戏数据中的 PS1 按键图标。</Description>
+    <DefaultValue>ff8_use_gamepad_icons = false</DefaultValue>
+    <TrueSetting>ff8_use_gamepad_icons = true</TrueSetting>
+    <FalseSetting>ff8_use_gamepad_icons = false</FalseSetting>
+  </Setting>
+
+  <Setting xsi:type="Checkbox">
+    <Group>控制</Group>
+    <Name>始终捕获输入</Name>
+    <Description>即使游戏窗口未处于焦点状态，也能继续接收手柄输入。</Description>
+    <DefaultValue>ff8_always_capture_input  = false</DefaultValue>
+    <TrueSetting>ff8_always_capture_input  = true</TrueSetting>
+    <FalseSetting>ff8_always_capture_input  = false</FalseSetting>
+  </Setting>
+
+  <!-- CHEATS TAB -->
+  <Setting xsi:type="DropDown">
+    <Group>快捷键</Group>
+    <Name>随机遇敌</Name>
+    <Description>开启或关闭随机遇敌。{0}使用方法：在游戏中按键盘 'CTRL+B'{0}	或 先按手柄 'L3' 再按 'Ο (B)'</Description>
+    <DefaultValue></DefaultValue>
+    <Option>
+      <Text>详见下方描述</Text>
+      <Settings></Settings>
+    </Option>
+  </Setting>
+
+  <Setting xsi:type="DropDown">
+    <Group>快捷键</Group>
+    <Name>跳过过场动画</Name>
+    <Description>跳过过场动画。有概率导致游戏卡死，建议仅用于跳过新游戏片头动画。{0}使用方法：在游戏中按键盘 'CTRL+S'{0}	或 先按手柄 'L3' 再按 '□ (X)'</Description>
+    <DefaultValue></DefaultValue>
+    <Option>
+      <Text>详见下方描述</Text>
+      <Settings></Settings>
+    </Option>
+  </Setting>
+
+  <Setting xsi:type="DropDown">
+    <Group>快捷键</Group>
+    <Name>游戏变速递进值</Name>
+    <Description>设置游戏加速/减速的递进值。每次按快捷键时，递进值越大，越能更快到达【最大加速倍数】，或更快减速恢复到【正常速度】。{0}使用方法：按键盘 'CTRL+↑/↓' 或 先按手柄 'L3' 再按 'L1/R1' 进行加速/减速，{0}	键盘'CTRL+←/→' 或 先按手柄 'L3' 再按 'L2/R2' 开启/关闭变速。</Description>
+    <DefaultValue>speedhack_step = 0.5</DefaultValue>
+    <Option>
+      <Text>0.5</Text>
+      <Settings>speedhack_step = 0.5</Settings>
+    </Option>
+    <Option>
+      <Text>1.0</Text>
+      <Settings>speedhack_step = 1.0</Settings>
+    </Option>
+    <Option>
+      <Text>2.0</Text>
+      <Settings>speedhack_step = 2.0</Settings>
+    </Option>
+  </Setting>
+
+  <Setting xsi:type="DropDown">
+    <Group>快捷键</Group>
+    <Name>最大加速倍数</Name>
+    <Description>设置游戏加速能达到的最大倍数。倍数越高，速度越快。{0}*需要关闭【垂直同步】才能使用游戏变速功能。</Description>
+    <DefaultValue>speedhack_max = 8.0</DefaultValue>
+    <Option>
+      <Text>2x</Text>
+      <Settings>speedhack_max = 2.0</Settings>
+    </Option>
+    <Option>
+      <Text>4x</Text>
+      <Settings>speedhack_max = 4.0</Settings>
+    </Option>
+    <Option>
+      <Text>6x</Text>
+      <Settings>speedhack_max = 6.0</Settings>
+    </Option>
+    <Option>
+      <Text>8x</Text>
+      <Settings>speedhack_max = 8.0</Settings>
+    </Option>
+    <Option>
+      <Text>10x</Text>
+      <Settings>speedhack_max = 10.0</Settings>
+    </Option>
+    <Option>
+      <Text>12x</Text>
+      <Settings>speedhack_max = 12.0</Settings>
+    </Option>
+  </Setting>
+
+  <!-- ADVANCED TAB -->
+  <Setting xsi:type="Checkbox">
+    <Group>高级</Group>
+    <Name>关联 Steam</Name>
+    <Description>与 FF8 Steam版进行关联，用于解锁游戏成就。</Description>
+    <DefaultValue>enable_steam_achievements = false</DefaultValue>
+    <TrueSetting>enable_steam_achievements = true</TrueSetting>
+    <FalseSetting>enable_steam_achievements = false</FalseSetting>
+  </Setting>
+
+  <Setting xsi:type="Checkbox">
+    <Group>高级</Group>
+    <Name>游戏内显示调试信息</Name>
+    <Description>在全屏模式下的画面左上角，或窗口模式下的标题栏中，显示有关渲染过程/性能的实时信息。</Description>
+    <DefaultValue>show_stats = false</DefaultValue>
+    <TrueSetting>show_stats = true</TrueSetting>
+    <FalseSetting>show_stats = false</FalseSetting>
+  </Setting>
+
+  <Setting xsi:type="Checkbox">
+    <Group>高级</Group>
+    <Name>显示驱动版本</Name>
+    <Description>在全屏模式下的画面左上角，或窗口模式下的标题栏中，显示当前的驱动版本。</Description>
+    <DefaultValue>show_version = false</DefaultValue>
+    <TrueSetting>show_version = true</TrueSetting>
+    <FalseSetting>show_version = false</FalseSetting>
+  </Setting>
+
+  <Setting xsi:type="Checkbox">
+    <Group>高级</Group>
+    <Name>显示帧率</Name>
+    <Description>在全屏模式下的画面左上角，或窗口模式下的标题栏中，显示游戏实时帧率。</Description>
+    <DefaultValue>show_fps = false</DefaultValue>
+    <TrueSetting>show_fps = true</TrueSetting>
+    <FalseSetting>show_fps = false</FalseSetting>
+  </Setting>
+
+  <Setting xsi:type="Checkbox">
+    <Group>高级</Group>
+    <Name>显示图形API版本</Name>
+    <Description>在全屏模式下的画面左上角，或窗口模式下的标题栏中，显示当前使用的图形API版本(OpenGL/DirectX11)。</Description>
+    <DefaultValue>show_renderer_backend = false</DefaultValue>
+    <TrueSetting>show_renderer_backend = true</TrueSetting>
+    <FalseSetting>show_renderer_backend = false</FalseSetting>
+  </Setting>
+
+  <Setting xsi:type="DropDown">
+    <Group>高级</Group>
+    <Name>内部分辨率放大倍数</Name>
+    <Description>将游戏原生分辨率640x480乘以所选的倍数，提高画面精细度，并减少缩放产生的画面瑕疵。{0}倍数越高，对显卡性能的要求也越高。{0}带 * 号的选项是性能与画质的最佳平衡点。</Description>
+    <DefaultValue>internal_resolution_scale = 0</DefaultValue>
+    <Option>
+      <Text>Auto</Text>
+      <Settings>internal_resolution_scale = 0</Settings>
+    </Option>
+    <Option>
+      <Text>1x (可能导致画面模糊)</Text>
+      <Settings>internal_resolution_scale = 1</Settings>
+    </Option>
+    <Option>
+      <Text>2x</Text>
+      <Settings>internal_resolution_scale = 2</Settings>
+    </Option>
+    <Option>
+      <Text>*4x</Text>
+      <Settings>internal_resolution_scale = 4</Settings>
+    </Option>
+    <Option>
+      <Text>*6x</Text>
+      <Settings>internal_resolution_scale = 6</Settings>
+    </Option>
+    <Option>
+      <Text>8x</Text>
+      <Settings>internal_resolution_scale = 8</Settings>
+    </Option>
+  </Setting>
+
+</ConfigSpec>

--- a/AppUI/Resources/Languages/StringResources.br.xaml
+++ b/AppUI/Resources/Languages/StringResources.br.xaml
@@ -1171,6 +1171,8 @@ Você quer aplicar essa configuração e tentar de novo?</system:String>
     <!--DEV NOTE TO REMOVE: STRINGS BELOW ADDED 4/29/20-->
     <system:String x:Key="Italian">Italiano</system:String>
 
+    <system:String x:Key="SimplifiedChinese">Chinês Simplificado</system:String>
+
     <system:String x:Key="SetInGameControls">Ajustar Controles do Jogo</system:String>
     <system:String x:Key="Keyboard">Teclado</system:String>
     <system:String x:Key="Controller">Controle</system:String>

--- a/AppUI/Resources/Languages/StringResources.de.xaml
+++ b/AppUI/Resources/Languages/StringResources.de.xaml
@@ -1178,6 +1178,8 @@ Möchten Sie die Einstellung übernehmen und es erneut versuchen?</system:String
     <!--DEV NOTE: STRINGS BELOW ADDED 4/29/20-->
     <system:String x:Key="Italian">Italienisch</system:String>
 
+    <system:String x:Key="SimplifiedChinese">Vereinfachtes Chinesisch</system:String>
+
     <system:String x:Key="SetInGameControls">Spielsteuerung festlegen</system:String>
     <system:String x:Key="Keyboard">TASTATUR</system:String>
     <system:String x:Key="Controller">CONTROLLER</system:String>

--- a/AppUI/Resources/Languages/StringResources.es.xaml
+++ b/AppUI/Resources/Languages/StringResources.es.xaml
@@ -1179,6 +1179,8 @@ Por último, puedes seleccionar la ruta de las cinemáticas en 'Opciones general
 
     <!--DEV NOTE TO REMOVE: STRINGS BELOW ADDED 4/29/20-->
     <system:String x:Key="Italian">Italiano</system:String>
+
+    <system:String x:Key="SimplifiedChinese">Chino simplificado</system:String>
 	
     <system:String x:Key="SetInGameControls">Ajustar controles dentro del juego</system:String>
     <system:String x:Key="Keyboard">Teclado</system:String>

--- a/AppUI/Resources/Languages/StringResources.fr.xaml
+++ b/AppUI/Resources/Languages/StringResources.fr.xaml
@@ -1165,6 +1165,8 @@ Voulez-vous appliquer ce réglage et essayer à nouveau ?</system:String>
     <system:String x:Key="BrazilianPortuguese">Portugais brésilien</system:String>
     <system:String x:Key="Italian">Italien</system:String>
 
+    <system:String x:Key="SimplifiedChinese">Chinois simplifié</system:String>
+
     <!--DEV NOTE TO REMOVE: STRINGS BELOW ADDED 4/29/20-->
 
     <system:String x:Key="SetInGameControls">Contrôles en Jeu</system:String>

--- a/AppUI/Resources/Languages/StringResources.gr.xaml
+++ b/AppUI/Resources/Languages/StringResources.gr.xaml
@@ -1171,6 +1171,8 @@ Once done, do close the game and the launcher, and finally retry to click Play h
     <system:String x:Key="BrazilianPortuguese">Πορτογαλικά της Βραζιλίας</system:String>
     <system:String x:Key="Italian">ιταλικός</system:String>
 
+    <system:String x:Key="SimplifiedChinese">Απλοποιημένα Κινέζικα</system:String>
+
     <!--DEV NOTE TO REMOVE: STRINGS BELOW ADDED 4/29/20-->
 
     <system:String x:Key="SetInGameControls">Ορισμός Στοιχείων Ελέγχου Εντός Παιχνιδιού</system:String>

--- a/AppUI/Resources/Languages/StringResources.it.xaml
+++ b/AppUI/Resources/Languages/StringResources.it.xaml
@@ -1169,6 +1169,8 @@ Vuoi applicare questa modifica e riprovare?</system:String>
    <system:String x:Key="BrazilianPortuguese">Portoghese Brasiliano</system:String>
     <system:String x:Key="Italian">Italiano</system:String>
 
+    <system:String x:Key="SimplifiedChinese">Cinese semplificato</system:String>
+
     <!--DEV NOTE TO REMOVE: STRINGS BELOW ADDED 4/29/20-->
 
     <system:String x:Key="SetInGameControls">Imposta Controlli di Gioco</system:String>

--- a/AppUI/Resources/Languages/StringResources.ja.xaml
+++ b/AppUI/Resources/Languages/StringResources.ja.xaml
@@ -1156,6 +1156,8 @@ Do you want to apply the setting and try again?</system:String>
     <system:String x:Key="BrazilianPortuguese">Brazilian Portuguese</system:String>
     <system:String x:Key="Italian">Italian</system:String>
 
+    <system:String x:Key="SimplifiedChinese">簡体中国語</system:String>
+
     <!--DEV NOTE TO REMOVE: STRINGS BELOW ADDED 4/29/20-->
 
     <system:String x:Key="SetInGameControls">Set In-Game Controls</system:String>

--- a/AppUI/Resources/Languages/StringResources.zh.xaml
+++ b/AppUI/Resources/Languages/StringResources.zh.xaml
@@ -1,0 +1,1272 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:system="clr-namespace:System;assembly=mscorlib">
+
+    <!--Main Window Buttons-->
+    <system:String x:Key="Play">运行游戏</system:String>
+    <system:String x:Key="PlayWithMods">有模组运行 (默认)</system:String>
+    <system:String x:Key="PlayWithNoMods">无模组运行</system:String>
+    <system:String x:Key="PlayWithMinimalValidation">最小验证运行</system:String>
+    <system:String x:Key="PlayWithDebugLog">带调试日志运行</system:String>
+    <system:String x:Key="PlayWithVariableDump">带变量转储运行</system:String>
+
+    <system:String x:Key="PlayWithChocobo">带陆行鸟世界运行</system:String>
+
+    <system:String x:Key="Settings">设置</system:String>
+    <system:String x:Key="ChangeColorTheme">配色主题...</system:String>
+    <system:String x:Key="GeneralSettings">常规设置...</system:String>
+    <system:String x:Key="GameDriver">游戏驱动...</system:String>
+    <system:String x:Key="GameLauncher">游戏启动器...</system:String>
+    <system:String x:Key="Profiles">预设...</system:String>
+    <system:String x:Key="Language">界面语言...</system:String>
+
+
+    <system:String x:Key="Tools">工具</system:String>
+    <system:String x:Key="CatalogModCreationTool">Catalog/Mod 创建工具...</system:String>
+    <system:String x:Key="ChunkTool">Chunk 工具...</system:String>
+    <system:String x:Key="IROTools">IRO 工具...</system:String>
+
+    <system:String x:Key="Help">帮助</system:String>
+    <system:String x:Key="HelpOpen">打开帮助文档</system:String>
+    <system:String x:Key="HelpOpenAbout">关于 Junction VIII</system:String>
+
+    <system:String x:Key="MyMods">我的模组</system:String>
+    <system:String x:Key="MyModsTooltip">右键点击“我的模组”，可以打开存放模组的文件夹</system:String>
+
+    <system:String x:Key="BrowseCatalog">在线模组目录</system:String>
+    <system:String x:Key="BrowseCatalogTooltip">右键点击“在线模组目录”，可以跳转到在线模组目录设置（中国大陆网络需要VPN）</system:String>
+
+    <system:String x:Key="SearchHint">输入搜索关键词 ...</system:String>
+    <system:String x:Key="FiltersTooltip">点击展开，可以自定义选择过滤类型</system:String>
+
+    <system:String x:Key="StatusBarTooltip">点击查看软件日志</system:String>
+
+    
+    <!--Mod Info Panel-->
+    <system:String x:Key="ModInfoHeader" xml:space="preserve">模组信息</system:String>
+    <system:String x:Key="NameLabel">名称：</system:String>
+    <system:String x:Key="AuthorLabel">作者：</system:String>
+    <system:String x:Key="ReleasedLabel">更新时间:</system:String>
+    <system:String x:Key="CategoryLabel">类别:</system:String>
+    <system:String x:Key="VersionLabel">版本:</system:String>
+
+    <system:String x:Key="ClickHere">点击此处</system:String>
+    <system:String x:Key="None">无</system:String>
+
+    <system:String x:Key="AutoUpdateInstall">自动升级/安装</system:String>
+    <system:String x:Key="Ignore">忽略</system:String>
+    <system:String x:Key="Notify">提醒</system:String>
+
+    <system:String x:Key="DescriptionLabel">描述：</system:String>
+    <system:String x:Key="LinkLabel">发布链接:</system:String>
+    <system:String x:Key="ReadmeLabel">自述文档:</system:String>
+    <system:String x:Key="ReleaseNotesLabel">更新说明：</system:String>
+    <system:String x:Key="DonationLinkLabel">捐赠:</system:String>
+
+    <system:String x:Key="NoPreviewImage">无预览图</system:String>
+
+    
+    <!-- Browse Catalog Tab -->
+    <system:String x:Key="Name">名称</system:String>
+    <system:String x:Key="Author">作者</system:String>
+    <system:String x:Key="Released">更新日期</system:String>
+    <system:String x:Key="Category">类型</system:String>
+    <system:String x:Key="Size">大小</system:String>
+    <system:String x:Key="Inst">已安装</system:String>
+
+
+    <system:String x:Key="RefreshCatalogTooltip">强制更新所有已订阅的模组，然后刷新列表</system:String>
+    <system:String x:Key="DownloadModTooltip">下载选中的模组</system:String>
+    <system:String x:Key="ResetColumnsTooltip">重置排序</system:String>
+
+    <system:String x:Key="Item">项目</system:String>
+    <system:String x:Key="Progress">进度</system:String>
+    <system:String x:Key="Speed">下载速度</system:String>
+    <system:String x:Key="TimeLeft">剩余时间</system:String>
+
+    <system:String x:Key="CancelDownloadTooltip">取消选中的下载</system:String>
+
+    
+    <!--My Mods Tab-->
+    <system:String x:Key="Active">开启状态</system:String>
+
+    <system:String x:Key="ImportModTooltip">导入模组</system:String>
+    <system:String x:Key="MoveUpTooltip">左键点击向上移动/右键点击移动到最上方</system:String>
+    <system:String x:Key="MoveDownTooltip">左键点击向上移动/右键点击移动到末尾</system:String>
+    <system:String x:Key="AutoSortTooltip">按照模组名称及兼容规则，自动排序</system:String>
+    <system:String x:Key="ConfigureModTooltip">修改所选模组的设置</system:String>
+    <system:String x:Key="ActivateAllTooltip">开启所有模组</system:String>
+    <system:String x:Key="DeactivateAllTooltip">禁用所有模组</system:String>
+    <system:String x:Key="RefreshListTooltip">刷新列表，自动排序</system:String>
+    <system:String x:Key="UninstallModTooltip">删除模组</system:String>
+    
+    
+    <!--Generic MessageBox Buttons-->
+    <system:String x:Key="OK">确定</system:String>
+    <system:String x:Key="Cancel">取消</system:String>
+    <system:String x:Key="Close">关闭</system:String>
+    <system:String x:Key="Yes">是</system:String>
+    <system:String x:Key="No">否</system:String>
+    <system:String x:Key="Off">禁用</system:String>
+    <system:String x:Key="On">开启</system:String>
+    <system:String x:Key="ResetDefaults">还原默认</system:String>
+    <system:String x:Key="Save">保存</system:String>
+    <system:String x:Key="Load">加载</system:String>
+    <system:String x:Key="Go">开始</system:String>
+
+
+    <!--Window Titles-->
+    <system:String x:Key="GameLauncherWindowTitle">正在启动游戏……</system:String>
+    <system:String x:Key="CatalogCreationWindowTitle">模组与目录创建工具</system:String>
+    <system:String x:Key="GameDriverWindowTitle">配置游戏驱动设置</system:String>
+    <system:String x:Key="UnexpectedErrorWindowTitle">Junction VIII - 未知的错误！</system:String>
+    <system:String x:Key="AllowModToRun">允许加载模组吗？</system:String>
+    <system:String x:Key="Warning">警告</system:String>
+    <system:String x:Key="Requirements">必须的要求</system:String>
+    <system:String x:Key="ExternalDownload">从外部下载吗？</system:String>
+    <system:String x:Key="MissingPath">路径缺失</system:String>
+    <system:String x:Key="ExtractComplete">提取完成</system:String>
+    <system:String x:Key="InsertDisc">插入光盘</system:String>
+    <system:String x:Key="MissingRequiredInput">缺少必要的输入</system:String>
+    <system:String x:Key="IROToolsWindowTitle">IRO 工具</system:String>
+    <system:String x:Key="ChunkToolWindowTitle">Chunk 工具</system:String>
+    <system:String x:Key="ManageProfiles">管理预设文件</system:String>
+    <system:String x:Key="SetLanguageWindowTitle">选择语言</system:String>
+
+
+
+
+
+    <!--Allow Mod To Run Window-->
+    <system:String x:Key="NoDontActivateThisMod">不，禁用这个模组</system:String>
+    <system:String x:Key="YesActivateThisMod">好，开启这个模组</system:String>
+    <system:String x:Key="DontAskAgainForAnyMods">以后不要再询问这个问题</system:String>
+    
+    <!--Game Launcher Settings Window-->
+    <system:String x:Key="OptionsHeader" xml:space="preserve"> 设置 </system:String>
+    <system:String x:Key="AutoMountDisc">自动加载虚拟光驱</system:String>
+    <system:String x:Key="AutoMountDiscTooltip">在启动游戏时自动加载软件附带的.ISO虚拟光驱，仅限Windows 8/10/11系统。如果你使用Windows 7甚至更旧的系统，则需要自己手动加载.ISO虚拟光驱，或插入游戏光盘。</system:String>
+
+    <system:String x:Key="AutoDismountDisc">自动卸载虚拟光驱</system:String>
+    <system:String x:Key="AutoDismountDiscTooltip">在退出游戏时自动卸载软件附带的.ISO虚拟光驱，仅限Windows 8/10/11系统。如果你使用Windows 7甚至更旧的系统，则需要自己手动弹出.ISO虚拟光驱或游戏光盘。</system:String>
+
+    <system:String x:Key="AutoUpdatePath">自动更新光驱路径</system:String>
+    <system:String x:Key="AutoUpdatePathTooltip">自动检测光盘是否已更改驱动器号，并自动更新游戏所读取的路径。</system:String>
+
+    <system:String x:Key="ShowGameLauncher">启动游戏时显示加载窗口</system:String>
+    <system:String x:Key="ShowGameLauncherTooltip">通过窗口显示 FF8 启动过程中的详细日志。如果游戏无法启动，则需要通过这个窗口来查看报错原因，建议开启。</system:String>
+
+    <system:String x:Key="ControlsLabel">按键设置:</system:String>
+
+    <system:String x:Key="SaveControlsTooltip">保存你当前的游戏内按键设置。</system:String>
+    <system:String x:Key="DeleteControlsTooltip">删除所选的按键预设。</system:String>
+    
+    <system:String x:Key="CompatibilityHeader" xml:space="preserve"> 兼容性 </system:String>
+    <system:String x:Key="HighDpiScalingFix">高分辨率缩放修复</system:String>
+    <system:String x:Key="HighDpiScalingFixTooltip">可以修复游戏画面显示不全/无法居中。或者将你的Windows显示设置更改为100%缩放。</system:String>
+
+
+    <system:String x:Key="ImportMoviesHeader" xml:space="preserve"> 从游戏光盘导入过场动画 </system:String>
+    <system:String x:Key="Import">导入</system:String>
+    <system:String x:Key="ImportTooltip">提取游戏光盘里的过场动画文件，修复游戏丢失过场动画的问题。</system:String>
+
+
+    <system:String x:Key="AudioDeviceHeader" xml:space="preserve"> 音频输出设备 </system:String>
+    <system:String x:Key="SoundDeviceLabel">声音设备:</system:String>
+    <system:String x:Key="SoundDeviceTooltip">为游戏选择一个声音输出设备。</system:String>
+
+    <system:String x:Key="TestSoundTooltip">测试所选择的声音设备与音乐/音效的音量（由 Enrico Deiana 提供的技术）。</system:String>
+    <system:String x:Key="TestLeftSoundTooltip">试听左声道（由 Enrico Deiana 提供的技术）。</system:String>
+    <system:String x:Key="TestRightSoundTooltip">试听右声道（由 Enrico Deiana 提供的技术）。</system:String>
+
+    <system:String x:Key="MidiDeviceLabel">MIDI 设备:</system:String>
+    <system:String x:Key="MidiDataLabel">MIDI 数据:</system:String>
+    <system:String x:Key="MidiDeviceTooltip">为游戏选择一个 MIDI 输出设备。</system:String>
+
+    <system:String x:Key="SFXVolumeLabel">音效音量:</system:String>
+    <system:String x:Key="SFXVolumeTooltip">设置游戏内音效的音量。</system:String>
+
+    <system:String x:Key="MusicVolumeLabel">音乐音量:</system:String>
+    <system:String x:Key="MusicVolumeTooltip">设置游戏内音乐的音量。</system:String>
+
+    <system:String x:Key="VoiceVolumeLabel">语音音量:</system:String>
+    <system:String x:Key="VoiceVolumeTooltip">设置游戏内语音的音量（需要语音模组）。</system:String>
+
+    <system:String x:Key="AmbientVolumeLabel">环境效果音音量:</system:String>
+    <system:String x:Key="AmbientVolumeTooltip">设置游戏内环境效果音的音量（需要环境效果音模组）。</system:String>
+
+    <system:String x:Key="MovieVolumeLabel">过场动画音量:</system:String>
+    <system:String x:Key="MovieVolumeTooltip">设置游戏内过场动画的音量。</system:String>
+
+    <system:String x:Key="LogVolumeControl">数字音量控制</system:String>
+    <system:String x:Key="LogVolumeControlTooltip">如果你觉得音量变化不平稳，请关闭此选项。</system:String>
+
+    <system:String x:Key="ReverseSpeakers">左声道/右声道反转</system:String>
+    <system:String x:Key="ReverseSpeakersTooltip">将左声道/右声道反转。</system:String>
+
+
+    <system:String x:Key="GraphicsDriverHeader" xml:space="preserve"> 图形驱动选项</system:String>
+    <system:String x:Key="RendererLabel">渲染器:</system:String>
+    <system:String x:Key="RendererTooltip">选择一个图形驱动程序，用于渲染 FF8。模组只能在设置为“自定义 J8 游戏驱动”时生效。</system:String>
+
+    <system:String x:Key="QuarterScreen">四分之一屏</system:String>
+    <system:String x:Key="QuarterScreenTooltip">启动游戏窗口（四分之一屏幕大小）。仅在设置为“软件渲染器”或“Direct3D硬件加速”时生效。</system:String>
+
+    <system:String x:Key="FullScreen">全屏</system:String>
+    <system:String x:Key="FullScreenTooltip">全屏启动游戏。仅在设置为“软件渲染器”或“Direct3D硬件加速”时生效。</system:String>
+
+    <system:String x:Key="HardwareGraphicsTooltip">设置用于硬件加速的选项。仅在设置为“Direct3D硬件加速”时生效。</system:String>
+
+
+    <system:String x:Key="ProgramsToRunHeader" xml:space="preserve"> 启动游戏时优先运行的程序: </system:String>
+    <system:String x:Key="ProgramNameHint">输入程序的完整路径</system:String>
+    <system:String x:Key="ProgramArgsHint">输入程序参数</system:String>
+
+    <system:String x:Key="AddProgramTooltip">设置优先运行的程序，在启动游戏时，先运行该程序，再运行 FF8。</system:String>
+    <system:String x:Key="RemoveProgramTooltip">移除所选的程序。</system:String>
+    <system:String x:Key="EditProgramTooltip">编辑所选程序的参数。</system:String>
+    <system:String x:Key="MoveProgramUpTooltip">左键点击向上移动/右键点击移动到最上方。</system:String>
+    <system:String x:Key="MoveProgramDownTooltip">左键点击向下移动/右键点击移动到末尾。</system:String>
+    <system:String x:Key="BrowseProgramTooltip">浏览要运行的程序</system:String>
+
+    <system:String x:Key="ResetLauncherDefaultsTooltip">将页面内所有选项重置到默认状态。</system:String>
+    
+    <!--Catalog Creation Window-->
+    <system:String x:Key="CreateMod">创建模组 Mod</system:String>
+    <system:String x:Key="CreateCatalog">创建目录 Catalog</system:String>
+    <system:String x:Key="MegaLinkGenerator">Mega网盘链接生成器</system:String>
+
+    
+    <!--Chunk Tool Window-->
+    <system:String x:Key="SelectFlevelLabel">选择 FLEVEL:</system:String>
+    <system:String x:Key="OutputFolderLabel">输出文件夹:</system:String>
+
+    <system:String x:Key="SectionHeader" xml:space="preserve"> 区段 # </system:String>
+    <system:String x:Key="Section1">区段 1 场景对话 Field Script Dialog</system:String>
+    <system:String x:Key="Section2">区段 2 镜头矩阵 Camera Matrix</system:String>
+    <system:String x:Key="Section3">区段 3 模型加载器 Model Loader</system:String>
+    <system:String x:Key="Section4">区段 4 调色板 Palette</system:String>
+    <system:String x:Key="Section5">区段 5 可行走网格 Walkmesh</system:String>
+    <system:String x:Key="Section6">区段 6 瓦片地图 TileMap (Unused)</system:String>
+    <system:String x:Key="Section7">区段 7 随机战斗Encounter</system:String>
+    <system:String x:Key="Section8">区段 8 触发器 Triggers</system:String>
+    <system:String x:Key="Section9">区段 9 背景 Background</system:String>
+
+    <system:String x:Key="Extract">提取</system:String>
+
+
+    <!--Configure Mod Window-->
+    <system:String x:Key="ConfigureHeader" xml:space="preserve"> 自定义配置 </system:String>
+    <system:String x:Key="Preview">试听</system:String>
+    <system:String x:Key="Stop">停止</system:String>
+    <system:String x:Key="ResetToModDefaults">还原到初始状态</system:String>
+    
+    <!--MainWindow.xaml.cs Strings-->
+    <system:String x:Key="AreYouSureYouWantToPlayDebugWarning" xml:space="preserve">你确定要在这个模式下玩 FF8 吗？可能会导致极度缓慢并占用大量硬盘空间。
+
+这个模式仅用于排查单个模组的故障，以便向模组作者 / J8 开发者提交错误报告。</system:String>
+
+    <system:String x:Key="AreYouSureYouWantToExitPendingDownloads">下载尚未完成，确定退出吗？</system:String>
+    <system:String x:Key="ConfirmExit">确认退出</system:String>
+    <system:String x:Key="Exit">退出</system:String>
+
+    <system:String x:Key="CannotExitWhileImporting">模组导入过程中不要退出！否则数据会损坏。</system:String>
+
+    <!--MainWindowViewModel Strings-->
+    <system:String x:Key="StartedClickHereToViewAppLog">已启动 - 点击这里查看软件日志。</system:String>
+    <system:String x:Key="HintLabel">提示:</system:String>
+    <system:String x:Key="CheckingForUpdates">正在检查软件更新 ...</system:String>
+    <system:String x:Key="SelectAll">全选</system:String>
+    <system:String x:Key="Unknown">未知</system:String>
+
+    <system:String x:Key="UpdateAvailable">有新版本</system:String>
+    <system:String x:Key="UpdateDownloading">正在下载更新</system:String>
+
+    <system:String x:Key="NoUpdates">无更新</system:String>
+    <system:String x:Key="UpdatesIgnored">忽略更新</system:String>
+    <system:String x:Key="AutoUpdate">自动更新</system:String>
+
+    <system:String x:Key="FollowingErrorsFoundInConfiguration">在你的设置中存在以下错误:</system:String>
+    <system:String x:Key="ErrorsFoundInGeneralSettingsViewAppLog">游戏路径设置存在错误，请打开软件日志，查看报错原因。</system:String>
+
+    <system:String x:Key="AppUpdateIsAvailableMessage" xml:space="preserve">{0} 有新版本 \n 点击“是”进行更新 \n\n{1} 更新日志:</system:String>
+    <system:String x:Key="NewVersionAvailable">有新版本！</system:String>
+
+    <system:String x:Key="ThisModContainsDataThatCouldHarm" xml:space="preserve">'{0}' 会为 EXE 注入代码，可能会有病毒。为了保障电脑安全，请确保你要开启的模组来自可信任的作者。例如直接从“在线模组目录”下载的模组。
+
+确定开启此模组？</system:String>
+
+    <system:String x:Key="CannotOpenHelp">无法打开帮助文档 - 软件根目录下 Resources/Help/index.html 文件丢失</system:String>
+
+    <system:String x:Key="SubscriptionIsAlreadyAdded">模组 {0} 已经存在。</system:String>
+    <system:String x:Key="AddedToSubscriptions">将在线模组 {0} 添加到“我的模组”中。</system:String>
+    <system:String x:Key="IrosLinkMayBeFormatedIncorrectly">iroj:// 链接 {0} 的格式可能不正确，无法添加。</system:String>
+
+    <system:String x:Key="FailedToSetBackgroundImageFromTheme">背景图片导入失败。</system:String>
+
+
+
+
+    <!--MyModsViewModel Strings-->
+    
+    <system:String x:Key="ModRequiresModsIsMissingWarning" xml:space="preserve">这个模组需要搭配下列模组:
+{0}
+如果你没有安装并开启这些模组，则可能无法正常运行。</system:String>
+
+    <system:String x:Key="UnsupportedModVersionsWarning" xml:space="preserve">这个模组需要搭配下列模组:
+{0}
+但版本已过时，你需要更新这些模组。</system:String>
+
+    <system:String x:Key="ThisModRequiresYouActivateFollowingMods" xml:space="preserve">这个模组需要搭配下列模组:
+{0}
+这些模组将会自动开启。</system:String>
+
+    <system:String x:Key="ModRequiresYouDeactivateTheFollowingMods" xml:space="preserve">这个模组*不兼容*下列模组:
+{0}
+这些模组将会自动禁用。</system:String>
+
+
+    <system:String x:Key="CannotActivateModBecauseItIsIncompatibleWithOtherMod" xml:space="preserve">无法开启此模组，它与 {0} 不兼容。你需要先将 {0} 禁用，才能开启此模组。</system:String>
+
+    <system:String x:Key="CannotActivateModBecauseDependentIsIncompatible" xml:space="preserve">无法开启此模组，它需要与 {0} 搭配使用，但 {0} 与 {1} 不兼容。你需要先将 {1} 禁用，才能开启此模组。</system:String>
+
+    <system:String x:Key="MissingRequirements">缺失必要内容</system:String>
+    <system:String x:Key="UnsupportedVersion">不支持的版本</system:String>
+    <system:String x:Key="MissingRequiredActiveMods">缺失需要开启的模组</system:String>
+    <system:String x:Key="DeactivateModsWarning">禁用模组警告</system:String>
+    <system:String x:Key="Uninstalled">未安装</system:String>
+
+    <system:String x:Key="CanNotReOrderModItHasBeenRemoved">无法添加 {0}，它不在存放模组的文件夹里。</system:String>
+    <system:String x:Key="CanNotConfigureModItHasBeenRemoved">无法配置 {0}，它不在存放模组的文件夹里。</system:String>
+    <system:String x:Key="CanNotConfigureModFailedToReadModXml">无法配置 {0}， - 无法读取它的 mod.xml</system:String>
+
+    <system:String x:Key="NoOptions">无可选项</system:String>
+    <system:String x:Key="ThereAreNoOptionsToConfigureForThisMod">这个模组没有可选项。</system:String>
+
+    <system:String x:Key="NewVersionOfModAvailable">{0} 有新版本</system:String>
+
+
+    <!--CatalogViewModel Strings-->
+
+    <system:String x:Key="ThisModAlsoRequiresYouDownloadTheFollowing" xml:space="preserve">这个模组需要搭配下列模组:
+{0}
+确定一起下载安装吗？</system:String>
+
+    <system:String x:Key="ThisModRequiresTheFollowingButCouldNotBeFoundInCatalog" xml:space="preserve">这个模组需要搭配下列模组:
+{0}
+并未在存放模组的文件夹检测到这些模组。</system:String>
+
+    <system:String x:Key="PauseResumeSelectedDownload">暂停/恢复 所选的下载</system:String>
+    <system:String x:Key="PauseSelectedDownload">暂停所选的下载</system:String>
+    <system:String x:Key="ResumeSelectedDownload">恢复所选的下载</system:String>
+
+    <system:String x:Key="NoResultsFound">未找到结果</system:String>
+    <system:String x:Key="CheckingSubscription">正在检查已安装的模组</system:String>
+    <system:String x:Key="CheckingCatalog">正在检查目录</system:String>
+    <system:String x:Key="UpdatedCatalogFrom">更新目录</system:String>
+    <system:String x:Key="FailedToLoadSubscription">已安装模组加载失败</system:String>
+    <system:String x:Key="CatalogDownloadFailed">目录下载失败</system:String>
+
+    <system:String x:Key="Starting">正在开始...</system:String>
+    <system:String x:Key="Pending">待处理...</system:String>
+    <system:String x:Key="Resuming">正在恢复...</system:String>
+    <system:String x:Key="Paused">已暂停...</system:String>
+    <system:String x:Key="Canceled">已取消</system:String>
+    <system:String x:Key="Failed">失败</system:String>
+
+    <system:String x:Key="IsAlreadyDownloading">已经正在下载！</system:String>
+    <system:String x:Key="IsAlreadyUpdating">已经正在升级！</system:String>
+    <system:String x:Key="IsAlreadyDownloadedAndInstalled">已经下载安装过了！</system:String>
+
+    <system:String x:Key="NoLinksFor">无链接指向</system:String>
+    <system:String x:Key="FailedToParseLinkFor">无法解析链接</system:String>
+    <system:String x:Key="OpeningExternalUrlInBrowserFor">在浏览器中打开外部链接</system:String>
+
+    <system:String x:Key="ErrorDownloading">下载出错</system:String>
+    <system:String x:Key="WasCanceled">已经被取消</system:String>
+    <system:String x:Key="Error">出错</system:String>
+    
+    <system:String x:Key="ExternalUrlDownloadMessage1" xml:space="preserve">这个模组只能从外部网站下载。
+        
+你想现在打开网页浏览器下载它吗？</system:String>
+
+    <system:String x:Key="ExternalUrlDownloadMessage2" xml:space="preserve">模组自动下载失败。但它的外部下载链接是可用的。
+
+你想现在打开网页浏览器下载它吗？</system:String>
+
+    <system:String x:Key="SwitchingToBackupUrl">切换到备用链接</system:String>
+    <system:String x:Key="Downloading">正在下载</system:String>
+    <system:String x:Key="Installing">正在安装</system:String>
+
+
+    <!--ChunkToolViewModel Strings-->
+    <system:String x:Key="PathToFlevelRequired">需要 Flevel 所在的文件夹路径。</system:String>
+    <system:String x:Key="PathToOutputFolderRequired">需要输出文件夹路径。</system:String>
+    <system:String x:Key="SelectTheSectionsToExtract">选择要提取的区段。</system:String>
+    <system:String x:Key="FlevelFileDoesNotExistAtGivenPath">无法在指定的文件夹路径找到 Flevel文件。</system:String>
+    <system:String x:Key="OutputFolderDoesNotExist">输出文件夹不存在。</system:String>
+
+    <system:String x:Key="Complete">完成！</system:String>
+    <system:String x:Key="FailedToExtractTheErrorHasBeenLogged">提取失败。错误已记录。</system:String>
+
+
+    <!--ConfigureModViewModel Strings-->
+    <system:String x:Key="ConfigureMod">自定义配置</system:String>
+
+    <system:String x:Key="ThisOptionCannotBeChangedDueToCompatibility">为了兼容其它模组，这个选项不可修改</system:String>
+    <system:String x:Key="TheFollowingValuesHaveBeenRemovedDueToCompatibility"> {0} 选项已被移除，否则不兼容其它模组 ({1})</system:String>
+
+    <system:String x:Key="FailedToPlayPreviewAudio">预览音频播放失败</system:String>
+
+
+    <!--DownloadItemViewModel Strings-->
+    <system:String x:Key="DownloadingPreviewImage">正在下载预览图片</system:String>
+
+    
+    
+    <!--GameLaunchSettingsViewModel Strings-->
+    <system:String x:Key="InsertAndClickImport">选择 {0} 然后点击“导入”</system:String>
+    <system:String x:Key="GameLauncherSettingsUpdated">设置已更新！</system:String>
+    <system:String x:Key="FailedToSaveLaunchSettings">设置保存失败</system:String>
+
+    <system:String x:Key="ErrorCopyingFf8InputCfg">复制 ff8input.cfg 失败</system:String>
+    <system:String x:Key="NoFf8InputCfgFoundAt">未找到 ff8input.cfg，路径：</system:String>
+    <system:String x:Key="AlreadyExistsAt">已经存在于</system:String>
+
+    <system:String x:Key="ChoosingAnyOtherOptionBesidesCustomJ8GameDriver">选择“自定义 J8 游戏驱动”以外的选项，将导致通过 J8 安装的模组失效！</system:String>
+
+    <system:String x:Key="YouShouldLeaveThisSettingOn">不要关闭此选项！</system:String>
+    <system:String x:Key="ProgramToRunNotFound">未找到要运行的程序</system:String>
+
+    <system:String x:Key="ImportMissingMoviesWarningMessage" xml:space="preserve">这个操作将从游戏光盘提取过场动画文件，并复制到游戏文件夹。这个过程将会覆盖 {0} 中已经存在的过场动画文件。
+
+确定要继续吗？</system:String>
+
+    <system:String x:Key="LookingFor">正在寻找</system:String>
+    <system:String x:Key="InsertToContinue">插入 {0} 以便继续</system:String>
+    
+    <system:String x:Key="PleaseInsertToContinueCopying" xml:space="preserve">请插入 {0} 以便继续复制缺失的过场动画文件。
+
+点击“取消”中止进程。</system:String>
+
+    <system:String x:Key="FoundDiscAt">{0} 已在下列位置找到: </system:String>
+    <system:String x:Key="Overwriting">正在覆盖</system:String>
+    <system:String x:Key="Copying">正在复制</system:String>
+    <system:String x:Key="FailedToFindAt">无法在 {1} 找到 {0}</system:String>
+    <system:String x:Key="AnErrorOccurredCopyingMovies">复制过场动画文件时发生错误</system:String>
+    <system:String x:Key="SuccessfullyCopiedMovies">过场动画文件已成功复制。</system:String>
+    <system:String x:Key="FinishedCopyingMoviesSomeFailed">过场动画文件复制完成。部分文件复制失败。详见程序日志。</system:String>
+
+    <system:String x:Key="SaveControlConfiguration">保存按键设置</system:String>
+    <system:String x:Key="ImportCurrentControlsFromGameAndSaveAs">从游戏中导入当前的按键设置，并另存为...</system:String>
+    <system:String x:Key="SaveError">保存出错</system:String>
+    <system:String x:Key="ControlNameIsEmpty">按键配置文件的名称不能为空。</system:String>
+    <system:String x:Key="ControlNameContainsInvalidChars">按键配置文件的名称不能包含特殊符号。</system:String>
+
+    <system:String x:Key="ControlsWithThatNameAlreadyExist">已存在同名文件。</system:String>
+
+    <system:String x:Key="SuccessfullyCreatedCustomControls">自定义按键配置文件创建成功。</system:String>
+    <system:String x:Key="FailedToCreateCustomControls">自定义按键配置文件创建失败。</system:String>
+
+    <system:String x:Key="SuccessfullyDeletedCustomControls">自定义按键配置文件删除成功。</system:String>
+    <system:String x:Key="FailedToDeleteCustomControls">自定义按键配置文件删除失败。</system:String>
+    
+    
+    <!--GeneralSettingsViewModel Strings-->
+    <system:String x:Key="EnterNameForCatalog">输入目录名称</system:String>
+    <system:String x:Key="GeneralSettingsHaveBeenUpdated">常规设置已更新！</system:String>
+
+    <system:String x:Key="SettingsNotValid">设置无效</system:String>
+    <system:String x:Key="MissingFf8ExePath">缺少 FF8 exe 路径。</system:String>
+    <system:String x:Key="MissingLibraryPath">存放模组的文件夹路径丢失</system:String>
+    <system:String x:Key="PromptMoveModsToNewLibrary">存放模组的文件夹位置已经改变。是否将现有的模组文件移动到新的位置？</system:String>
+    <system:String x:Key="MovedModsToNewLibrary">模组文件已经移动到新的位置。</system:String>
+    <system:String x:Key="FailedToMoveModsToNewLibrary">无法将模组文件移动到新的位置。查看日志以获取详细信息。</system:String>
+    <system:String x:Key="MissingTexturesPath">存放自定义贴图 (Aali OpenGL) 的文件夹路径丢失</system:String>
+    <system:String x:Key="MissingMoviePath">过场动画文件路径丢失</system:String>
+    <system:String x:Key="LibraryPathCannotBeGameOrApp">存放模组的文件夹路径不能是 Junction VIII 软件根目录，也不能是游戏根目录！请使用默认路径或选择其他非上述路径。</system:String>
+
+    <system:String x:Key="FailedToRegisterIroModFilesWithJunctionVIII">向 Junction VIII 注册 .iroj 模组文件失败</system:String>
+    <system:String x:Key="FailedToUnregisterIroModFilesWithJunctionVIII">从 Junction VIII 取消注册 .iroj 模组文件失败</system:String>
+    <system:String x:Key="FailedToUnregisterIrosLinksWithJunctionVIII">从 Junction VIII 取消注册 iroj:// 链接失败</system:String>
+    <system:String x:Key="FailedToRegisterIrosLinksWithJunctionVIII">向 Junction VIII 注册 iroj:// 链接失败</system:String>
+    <system:String x:Key="FailedToCreateJunctionVIIIContextMenuEntries">在 Windows 资源管理器中创建 Junction VIII 右键菜单项失败</system:String>
+    <system:String x:Key="FailedToRemoveJunctionVIIIContextMenuEntries">在 Windows 资源管理器中移除 Junction VIII 右键菜单项失败</system:String>
+
+    <system:String x:Key="CatalogNameWillAutoResolveOnSave">目录名称将在保存时自动解析</system:String>
+    <system:String x:Key="ResolvingCatalogName">正在解析目录名称 ...</system:String>
+    <system:String x:Key="UrlMustBeInIrosFormat">链接必须是 iroj:// 格式</system:String>
+    <system:String x:Key="ResolvingCatalogNameFor">正在解析以下目录的名称: </system:String>
+    
+    
+    <!--ImportModViewModel Strings-->
+    <system:String x:Key="SelectAnIroFileToImport">选择一个 .iroj 或 .irojp 文件导入到存放模组的文件夹。</system:String>
+    <system:String x:Key="SelectAFolderThatContainsModFiles">选择一个包含模组文件的文件夹。模组文件将被复制到“存放模组的文件夹”。</system:String>
+    <system:String x:Key="SelectAFolderThatContainsIroModFilesAndFolders">选择一个包含 .iroj 模组文件和模组文件夹的位置。所有找到的模组文件将被复制到“存放模组的文件夹”。</system:String>
+    <system:String x:Key="ImportingModsPleaseWait">正在导入模组... 请稍等 ...</system:String>
+
+    <system:String x:Key="ValidationError">验证出错</system:String>
+    <system:String x:Key="ImportError">导入出错</system:String>
+
+    <system:String x:Key="EnterPathToAnIroFile">请输入 .iroj 文件所在文件夹的路径。</system:String>
+    <system:String x:Key="IroFileDoesNotExist">.iroj 文件不存在。</system:String>
+
+    <system:String x:Key="SuccessfullyImported">已成功导入</system:String>
+    <system:String x:Key="CanNotImportMod">无法导入模组。</system:String>
+    <system:String x:Key="FailedToImportModTheErrorHasBeenLogged">导入模组失败。错误已记录。</system:String>
+
+    <system:String x:Key="EnterPathToFolderContainingModFiles">请输入包含模组文件的文件夹路径。</system:String>
+    <system:String x:Key="DirectoryDoesNotExist">文件夹不存在。</system:String>
+
+    <system:String x:Key="EnterPathToFolderContainingIroFilesOrModFolders">请输入包含 .iroj 文件、模组文件夹的路径。</system:String>
+
+    <!--MegaLinkGenUserControl Strings-->
+    <system:String x:Key="GenerateLinks">生成链接</system:String>
+
+    <!--MegaLinkGenViewModel Strings-->
+    <system:String x:Key="GeneratingLinks">正在生成链接 ...</system:String>
+    <system:String x:Key="FailedToGenerateLinks">生成链接失败</system:String>
+    <system:String x:Key="EnterMegaFolderIdToGenerateLinks">请输入要生成链接的 Mega网盘文件夹ID。</system:String>
+    <system:String x:Key="NoLinksFoundInFolder">文件夹中找不到链接</system:String>
+    
+    
+    <!--CreateModUserControl Strings-->
+    <system:String x:Key="Generate">生成</system:String>
+    <system:String x:Key="Info">信息</system:String>
+    <system:String x:Key="MakeSureToCopyToTheRootFolder">将 {0} 复制到模组根目录，才能正确加载预览图像。</system:String>
+
+    <!--ModCreationViewModel Strings-->
+    <system:String x:Key="CouldNotLoadModXml">无法加载模组xml</system:String>
+    <system:String x:Key="CouldNotSaveModXml">无法保存模组xml</system:String>
+    <system:String x:Key="SuccessfullySavedTo">已成功保存到</system:String>
+    
+    
+    <!--OpenProfileWindow Strings-->
+    <system:String x:Key="LoadProfile">加载预设文件</system:String>
+    <system:String x:Key="SaveCurrentProfileAs">将当前预设文件另存为 ...</system:String>
+    <system:String x:Key="CopySelectedProfileToNewProfile">复制所选的预设文件</system:String>
+    <system:String x:Key="DeleteSelectedProfile">删除所选的预设文件</system:String>
+    <system:String x:Key="ViewSelectedProfileDetails">查看所选预设文件的参数</system:String>
+
+    <system:String x:Key="AreYouSureYouWantToDeleteSelectedProfile">确定删除所选的预设文件吗</system:String>
+
+    <system:String x:Key="NoProfileSelected">未选择预设文件</system:String>
+    <system:String x:Key="SelectProfileToContinue">选择一个预设文件以继续</system:String>
+
+
+    <!--OpenProfileViewModel Strings-->
+    <system:String x:Key="ActiveProfileFileDoesNotExist">正在使用的预设文件不存在</system:String>
+    <system:String x:Key="EnterProfileName">输入预设文件名称:</system:String>
+    <system:String x:Key="SaveActiveProfile">保存正在使用的预设文件</system:String>
+    <system:String x:Key="SuccessfullySavedAsNewProfile">成功将 {0} 保存为新的预设文件 {1}！</system:String>
+    <system:String x:Key="FailToSaveAsNewProfile">无法将 {0} 保存为新预设文件 {1}: {2}</system:String>
+
+    <system:String x:Key="ProfileDoesNotExist">预设文件不存在</system:String>
+    <system:String x:Key="HasItBeenDeletedAlready">是否已经删除？</system:String>
+    <system:String x:Key="SuccessfullyDeletedProfile">已成功删除预设文件</system:String>
+    <system:String x:Key="FailedToDeleteProfile">预设文件删除失败</system:String>
+
+    <system:String x:Key="EnterProfileNameForTheCopy">为复制的预设文件命名:</system:String>
+    <system:String x:Key="CopyProfile">复制预设</system:String>
+    <system:String x:Key="NewProfile">新建预设</system:String>
+    <system:String x:Key="SuccessfullyCopiedProfile">成功将 {0} 复制为新的预设文件 {1}</system:String>
+    <system:String x:Key="FailedToCopyProfile">无法将预设文件 {0} 复制为 {1}</system:String>
+
+    <system:String x:Key="FailedToOpenProfileDetails">无法打开预设文件查看参数</system:String>
+    <system:String x:Key="ProfileNameIsEmpty">预设文件名称为空。</system:String>
+    <system:String x:Key="ProfileError">预设文件出错</system:String>
+
+    <system:String x:Key="WarningProfileXmlDoesNotExistCanNotSwitch">警告：{0} 的预设文件 xml 不存在。无法切换预设文件！</system:String>
+    <system:String x:Key="LoadedProfile">已加载预设文件</system:String>
+    <system:String x:Key="FailedToSwitchToProfile">预设文件切换失败</system:String>
+
+
+    <!--PackIroViewModel Strings-->
+    <system:String x:Key="PathToSourceFolderIsRequired">需要源文件夹路径</system:String>
+    <system:String x:Key="PathToOutputIroFileIsRequired">需要输出iro文件的路径</system:String>
+    <system:String x:Key="SelectCompressionOption">选择一个压缩选项</system:String>
+    <system:String x:Key="InvalidPackIroOptions">无效的iro打包设置</system:String>
+    <system:String x:Key="AnErrorOccuredWhilePacking">打包过程出错</system:String>
+    <system:String x:Key="PackingComplete">打包完成！</system:String>
+
+    
+    <!--PatchIroViewModel Strings-->
+    <system:String x:Key="PathToOriginalIroIsRequired">需要原始iro文件的路径</system:String>
+    <system:String x:Key="PathToNewIroFileIsRequired">需要新的iro文件的路径</system:String>
+    <system:String x:Key="PathToIropFileIsRequired">需要iro文件的保存路径</system:String>
+    <system:String x:Key="AnErrorOccuredWhilePatching">修补过程出错</system:String>
+    <system:String x:Key="PatchingComplete">修补完成！</system:String>
+    
+    
+    <!--ThemeSettingsWindow Strings-->
+    <system:String x:Key="ChangeColorThemeWindowTitle">更改配色主题</system:String>
+    <system:String x:Key="ExportTheme">导出主题 ...</system:String>
+
+    <!--ThemeSettingsViewModel Strings-->
+    <system:String x:Key="ThemeSaved">主题已保存！</system:String>
+    <system:String x:Key="ThemeSavedAs">主题另存为</system:String>
+    <system:String x:Key="FailedToSaveTheme">主题保存失败...</system:String>
+    <system:String x:Key="FailedToLoadTheme">主题加载失败</system:String>
+    <system:String x:Key="ThemeLoadedClickSavveToSaveThis">主题已加载！点击“保存”将这个主题保存为默认 ...</system:String>
+    <system:String x:Key="SelectBackgroundImageFile">选择背景图片文件</system:String>
+
+    
+    <!--UnpackIroViewModel Strings-->
+    <system:String x:Key="PathToSourceIroFileIsRequired">需要iro源文件路径</system:String>
+    <system:String x:Key="InvalidUnpackIroOptions">无效的iro解包设置</system:String>
+    <system:String x:Key="AnErrorOccuredWhileUnpacking">解包过程出错</system:String>
+    <system:String x:Key="UnpackingComplete">解包完成！</system:String>
+
+    
+    <!--CreateCatalogUserControl Strings-->
+    <system:String x:Key="RemoveMod">移除模组</system:String>
+    <system:String x:Key="Add">添加</system:String>
+
+    <!--CatalogCreationViewModel Strings-->
+    <system:String x:Key="CouldNotLoadModXmlFromIroFile">无法从 .iroj 文件中加载模组 xml</system:String>
+    <system:String x:Key="CouldNotLoadCatalogXml">无法加载目录xml</system:String>
+
+    
+    <!--ConfigureGLWindow.xaml.cs Strings-->
+    <system:String x:Key="FailedToReadRequiredSpecXmlFile">无法读取显示设置所需的 spec xml 文件。窗口必须关闭。</system:String>
+    <system:String x:Key="WillDeleteEverythingUnder">将会删除以下的所有内容: </system:String>
+    <system:String x:Key="PathToCacheFolderDoesNotExist">缓存文件夹路径不存在。</system:String>
+    <system:String x:Key="TextureCacheCleared">纹理缓存已清除！</system:String>
+    <system:String x:Key="FailedToClearTextureCache">纹理缓存清除失败</system:String>
+    <system:String x:Key="GameDriverSettingsSaved">游戏驱动设置已保存！</system:String>
+    <system:String x:Key="CouldNotWriteToJ8GameDriverCfg">无法写入 FFNx.toml 文件。请检查该文件是否为只读，以及 FF8 是否安装在你拥有完整写入权限的文件夹中。</system:String>
+    <system:String x:Key="UnknownErrorWhileSaving">保存时发生未知错误。错误已记录。</system:String>
+    <system:String x:Key="GameDriverSettingsResetToDefaults">游戏驱动设置已还原到默认值。点击“保存”以保存更改。</system:String>
+
+    
+    
+    <!--GameLaunchSettingsWindow.xaml.cs Strings-->
+    <system:String x:Key="SelectProgramToRemove">选择要删除的程序。</system:String>
+    <system:String x:Key="SelectProgramToEdit">选择要编辑的程序。</system:String>
+    <system:String x:Key="SelectProgramToMove">选择要移动的程序。</system:String>
+    <system:String x:Key="SelectProgramToRunSuchAs">选择要运行的程序，例如 .exe 或脚本</system:String>
+    
+    
+    <!--GameLaunchWindow.xaml.cs Strings-->
+    <system:String x:Key="LaunchingFinalFantasyVII">正在启动 最终幻想VIII</system:String>
+    <system:String x:Key="UnknownErrorWhenLaunchingGame">启动游戏时发生未知错误</system:String>
+    <system:String x:Key="GameLaunchProcessCanceled">游戏启动过程已取消</system:String>
+    <system:String x:Key="FailedToLaunchFf8ViewLogForDetails">启动 FF8 失败。请查看上方日志了解详情。</system:String>
+    <system:String x:Key="SuccessfullyLaunchedFf8">已成功启动 FF8！</system:String>
+    
+    
+    <!--GeneralSettingsWindow Strings-->
+    <system:String x:Key="ActivateNewlyInstalledModsAutomatically">新安装的模组自动开启</system:String>
+    <system:String x:Key="ImportModsFromLibraryAutomatically">从存放模组的文件夹自动导入新模组</system:String>
+    <system:String x:Key="WarnWhenModContainsCode">当模组包含注入型代码时提出警告</system:String>
+    <system:String x:Key="AutoSortModsByDefault">自动调整模组加载顺序</system:String>
+    <system:String x:Key="AutoUpdateModsByDefault">自动升级模组</system:String>
+    <system:String x:Key="IgnoreModCompatibilityRestrictions">忽略模组兼容规则</system:String>
+    <system:String x:Key="CheckForJunctionVIIIUpdatesAutomatically">自动检查 Junction VIII 更新</system:String>
+
+    <system:String x:Key="OpenIrosLinksWithJunctionVIII">用 Junction VIII 打开 iroj:// 链接</system:String>
+    <system:String x:Key="OpenModFilesWithJunctionVIII">用 Junction VIII 打开模组文件</system:String>
+    <system:String x:Key="ContextMenuInExplorer">右键菜单选项</system:String>
+
+    <system:String x:Key="PathsHeader" xml:space="preserve"> 游戏路径 </system:String>
+    <system:String x:Key="ShellIntegrationHeader" xml:space="preserve"> Shell 集成 </system:String>
+    <system:String x:Key="CatalogSubscriptionsHeader" xml:space="preserve"> 在线模组目录订阅: </system:String>
+    <system:String x:Key="AdditionalFoldersToMonitorHeader" xml:space="preserve"> 游戏根目录下必要的文件夹: </system:String>
+
+    <system:String x:Key="Url">链接</system:String>
+
+    <system:String x:Key="ErrorIncorrectExe">出错 - 不正确的exe文件</system:String>
+    <system:String x:Key="ThisExeIsUsedForSteamReleaseFailedToCopyExe">这个 exe 适用于 FF8 Steam 版，而 Junction VIII 不支持该版本。ff8.exe 的 1.02 补丁复制失败，无法自动选择。</system:String>
+    <system:String x:Key="ThisExeIsUsedForSteamReleaseCopiedSelectedForYou">这个 exe 适用于 FF8 Steam 版，而 Junction VIII 不支持该版本。ff8.exe 的 1.02 补丁{0}，以确保 Junction VIII 能正常运行。</system:String>
+    <system:String x:Key="Selected">已应用</system:String>
+    <system:String x:Key="CopiedAndSelected">已复制并应用</system:String>
+    <system:String x:Key="ThisExeIsUsedForConfiguringFf8Settings">这个 exe 用于配置 FF8 设置，不是正确的游戏 exe。请选择另一个 FF8 EXE 文件。</system:String>
+
+    <system:String x:Key="SelectFf8Exe">选择 FF8.exe</system:String>
+    <system:String x:Key="SelectMoviesFolder">选择过场动画 movies文件夹</system:String>
+    <system:String x:Key="SelectTexturesFolder">选择外置贴图 Textures文件夹</system:String>
+    <system:String x:Key="SelectJunctionVIIILibraryFolder">选择 Junction VIII 存放模组的文件夹</system:String>
+
+    <system:String x:Key="SelectSubscriptionToEdit">选择一个要修改的订阅链接</system:String>
+    <system:String x:Key="SelectSubscriptionToRemove">选择一个要删除的订阅链接</system:String>
+    <system:String x:Key="SelectSubscriptionToMove">选择一个要移动的订阅链接</system:String>
+
+    <system:String x:Key="SelectFolderToRemove">选择一个要删除的文件夹</system:String>
+    <system:String x:Key="SelectFolderToMove">选择一个要移动的文件夹</system:String>
+    
+    
+    <!--ImportModWindow Strings-->
+    <system:String x:Key="FromIROFile">从 IRO文件</system:String>
+    <system:String x:Key="FromFolder">从文件夹</system:String>
+    <system:String x:Key="BatchImport">批量导入</system:String>
+    <system:String x:Key="SelectIroFile">选择 .iroj 文件</system:String>
+
+
+    <!--IroCreateWindow Strings-->
+    <system:String x:Key="PackIRO">打包IRO</system:String>
+    <system:String x:Key="UnpackIRO">解包IRO</system:String>
+    <system:String x:Key="PatchIRO">修补IRO</system:String>
+    <system:String x:Key="PatchIROAdvanced">修补IRO (高级)</system:String>
+
+
+    <!--UnhandledErrorWindow Strings-->
+    <system:String x:Key="AnUnhandledExceptionOccurredAppMustClose">出现了未处理的异常，Junction VIII 必须关闭。</system:String>
+
+
+    <system:String x:Key="SelectLanguage">选择语言:</system:String>
+    <system:String x:Key="English">英语</system:String>
+    <system:String x:Key="French">法语</system:String>
+    <system:String x:Key="German">德语</system:String>
+    <system:String x:Key="Spanish">西班牙语</system:String>
+    <system:String x:Key="Japanese">日语</system:String>
+
+
+    <!--GameLauncher Strings-->
+    <system:String x:Key="CheckingFf8IsNotRunning">正在检查 FF8 是否未在运行 ...</system:String>
+    <system:String x:Key="Ff8IsAlreadyRunning">FF8 已在运行！</system:String>
+    <system:String x:Key="Ff8IsAlreadyRunningDoYouWantToForceClose" xml:space="preserve">FF8 已在运行。是否强制关闭它？
+
+点击“是”，关闭当前所有 FF8 进程；点击“否”，另外启动一个新的 FF8 进程。</system:String>
+
+    <system:String x:Key="ForceClosingAllInstancesFf8">正在强制关闭所有 FF8 进程 ...</system:String>
+    <system:String x:Key="Aborting">出现异常 ...</system:String>
+    <system:String x:Key="FailedToCloseProcess">进程关闭失败</system:String>
+    <system:String x:Key="CheckingFf8ExeExistsAt">正在检查 FF8 .exe 是否存在于</system:String>
+    <system:String x:Key="CheckingFF8SteamInstalledCorrectly">正在检查 FF8 Steam 版是否安装正确 ...</system:String>
+    <system:String x:Key="FF8SteamNotInstalledCorrectly" xml:space="preserve">未找到用户配置文件。看起来你的 Steam 版游戏还没有运行过。
+
+接下来 Junction VIII 会为你启动原版游戏，请确保点击 Play 并至少运行一次游戏。
+
+完成后，请关闭游戏和启动器，最后再回到 Junction VIII 点击启动按钮重试。</system:String>
+    <system:String x:Key="FileNotFoundAborting">文件丢失，出现异常 ...</system:String>
+    <system:String x:Key="Ff8ExeNotFoundYouMayNeedToConfigure">未找到 FF8.exe。你可能需要通过“设置 → 常规设置”菜单配置 J8。</system:String>
+    <system:String x:Key="VerifyingInstalledGameIsCompatible">正在验证安装的游戏是否兼容 ...</system:String>
+    <system:String x:Key="ErrorCodeYarr">EXE/DLL 完整性检查失败，请从 CD 重新安装或使用“验证我的文件”进行修复。</system:String>
+    <system:String x:Key="VerifyingGameIsNotInstalledInProtectedFolder">正在验证游戏是否被安装到了系统文件夹/受保护的文件夹 ...</system:String>
+
+    <system:String x:Key="Ff8IsCurrentlyInstalledInASystemFolder" xml:space="preserve">FF8 当前安装在系统文件夹中，这可能导致模组失效。建议将游戏安装到 C:\Games\Final Fantasy VIII。
+
+是否要自动把你的游戏复制到 C:\Games\Final Fantasy VIII 并继续？</system:String>
+
+    <system:String x:Key="CanNotContinueDueToFf8nstalledInProtectedFolder">由于 FF8 安装在系统/受保护的文件夹中，无法继续。正在中止 ...</system:String>
+    <system:String x:Key="CannotContinue">无法继续！</system:String>
+
+    <system:String x:Key="CopyingGameFilesTo">正在将游戏文件复制到</system:String>
+    <system:String x:Key="FailedToCopyFf8To">复制 FF8 到以下路径失败：</system:String>
+
+    <system:String x:Key="VerifyingGameIsMaxInstall">正在验证游戏是否完整/最大安装 ...</system:String>
+    <system:String x:Key="YourFf8InstallationFolderIsMissingCriticalFiles" xml:space="preserve">你的 FF8 安装文件夹缺少关键文件。安装 FF8 时，你可能误选了“标准安装（Standard Install）”，而游戏需要“完整安装（Maximum Install）”。
+
+Junction VIII 可以自动修复此问题。只需插入一张游戏光盘并重试即可。</system:String>
+
+    <system:String x:Key="CreatingMissingRequiredDirectories">正在创建缺失的必要目录 ...</system:String>
+    <system:String x:Key="VerifyingAdditionalFilesForBattleAndKernelFoldersExist">正在验证“battle”和“kernel”文件夹的附加文件是否存在 ...</system:String>
+    <system:String x:Key="FailedToVerifyCopyMissingAdditionalFiles">验证/复制缺失的附加文件失败。正在中止...</system:String>
+
+    <system:String x:Key="VerifyingAllMovieFilesExist">正在验证所有过场动画文件是否存在 ...</system:String>
+    <system:String x:Key="CouldNotFindAllMovieFilesAt">无法在以下位置找到所有过场动画文件: </system:String>
+    <system:String x:Key="AllFilesFoundAt">所有文件已在以下位置找到: </system:String>
+    <system:String x:Key="UpdatingMoviePathSetting">正在更新 过场动画movie文件夹路径设置</system:String>
+    <system:String x:Key="AttemptingToCopyMovieFiles">正在尝试复制过场动画文件 ...</system:String>
+
+    <system:String x:Key="MovieFilesAreMissing">过场动画文件丢失！</system:String>
+    <system:String x:Key="InOrderToSeeInGameMoviesYouWillNeedMessage" xml:space="preserve">为了在游戏中正常播放过场动画，你需要下载并启用一个过场动画模组。
+
+或者打开“工具 → 过场动画导入工具”，从 FF8 光盘中提取过场动画文件，导入到游戏文件夹中。
+
+最后，你也可以在“常规设置”中将过场动画路径指向游戏光盘的 'FF8\Movies' 文件夹，但这样在游戏过程中需要手动更换光盘。</system:String>
+
+    <system:String x:Key="VerifyingMusicFilesExist">正在验证音乐文件是否存在 ...</system:String>
+    <system:String x:Key="CouldNotFindAllMusicFilesAt">无法在以下位置找到所有音乐文件: </system:String>
+    <system:String x:Key="AttemptingToCopyMusicFiles">正在尝试复制音乐文件 ...</system:String>
+
+    <system:String x:Key="VerifyingLatestGameDriverIsInstalled">正在验证是否安装了最新的游戏驱动 ...</system:String>
+    <system:String x:Key="SomethingWentWrongTryingToDetectGameDriver">尝试检测/安装游戏驱动时出错。正在中止 ...</system:String>
+    <system:String x:Key="VerifyingGameDriverShadersFoldersExist">正在验证游戏驱动的着色器文件夹是否存在 ...</system:String>
+
+    <system:String x:Key="VerifyingFf8Exe">正在验证 ff8.exe ...</system:String>
+    <system:String x:Key="VerifyingFf8LauncherExe">正在验证 FF8_Launcher.exe ...</system:String>
+    <system:String x:Key="Ff8ExePathChanged">检测到游戏路径已更改，强烈建议你重启 Junction VIII。是否现在重启？</system:String>
+    <system:String x:Key="Ff8ExeDetectedToBeDifferent">检测到 ff8.exe 与预期不一致。正在创建备份并复制正确的 .exe ...</system:String>
+    <system:String x:Key="FailedToCopyFf8Exe">复制 ff8.exe 失败。正在中止 ...</system:String>
+    <system:String x:Key="FailedToCreateBackupOfFf8Exe">创建 ff8.exe 备份失败。正在中止 ...</system:String>
+
+    <system:String x:Key="Ff8ConfigExeDetectedToBeMissingOrDifferent">FF8Config.exe 缺失或检测到与预期不一致。正在创建备份（若已存在）并复制正确的 .exe ...</system:String>
+    <system:String x:Key="FailedToCopyFf8ConfigExe">复制 FF8Config.exe 失败。正在中止 ...</system:String>
+    <system:String x:Key="FailedToCreateBackupOfFf8ConfigExe">创建 FF8Config.exe 备份失败。正在中止 ...</system:String>
+
+    <system:String x:Key="VerifyingEAXUnifiedIsInstalled">正在验证 EAXUnified 是否已安装 ...</system:String>
+    <system:String x:Key="InstallingEAXUnified">未找到 eax.dll，正在安装 EAXUnified。可能会弹出 UAC 提示，请点击允许以继续 ...</system:String>
+    <system:String x:Key="FailedToInstallEAXUnified">安装 EAXUnified 失败。正在中止 ...</system:String>
+
+    <system:String x:Key="CheckingAProfileIsActive">正在检查是否有正在使用的预设文件 ...</system:String>
+    <system:String x:Key="ActiveProfileNotFound">找不到正在使用的预设文件。正在中止 ...</system:String>
+    <system:String x:Key="CreateAProfileFirstAndTryAgain">请先在“设置 → 预设”里创建一个预设文件，然后重试。</system:String>
+
+    <system:String x:Key="CheckingModCompatibilityRequirements">正在检查模组兼容的要求 ...</system:String>
+    <system:String x:Key="FailedModCompatibilityCheck">模组兼容检查失败。正在中止 ...</system:String>
+
+    <system:String x:Key="CheckingModConstraintsForCompatibility">正在检查模组兼容规则 ...</system:String>
+    <system:String x:Key="FailedModConstraintCheck">模组兼容规则检查失败。正在中止 ...</system:String>
+
+    <system:String x:Key="CheckingModLoadOrderRequirements">正在检查模组加载顺序的要求 ...</system:String>
+    <system:String x:Key="FailedModLoadOrderCheck">模组加载顺序检查失败。正在中止 ...</system:String>
+
+    <system:String x:Key="LookingForGameDisc">正在寻找游戏光盘 ...</system:String>
+    <system:String x:Key="FoundGameDiscAt">已在以下位置找到游戏光盘: </system:String>
+    <system:String x:Key="FailedToFindGameDisc">无法找到游戏光盘 ...</system:String>
+    <system:String x:Key="OsDoesNotSupportAutoMounting">操作系统不支持自动挂载虚拟光驱。必须挂载一个名为 FF8DISC1.ISO 的虚拟光驱，或插入一个名为 FF8DISC1 的 U 盘，或将一个硬盘驱动器重命名为 FF8DISC1 ...</system:String>
+    <system:String x:Key="AutoMountingVirtualGameDisc">正在自动挂载虚拟游戏光驱 ...</system:String>
+    <system:String x:Key="FailedToAutoMountVirtualDiscAt">无法在以下位置自动挂载虚拟光驱: </system:String>
+    <system:String x:Key="LookingForGameDiscAfterMounting">已挂载，正在寻找游戏光盘 ...</system:String>
+    <system:String x:Key="FailedToFindGameDiscAfterAutoMounting">自动挂载后无法找到游戏光盘 ...</system:String>
+
+    <system:String x:Key="UserRequestedToPlayWithNoModsLaunchingGameAsVanilla">用户请求无模组游玩。正在以“原版”模式启动游戏 ...</system:String>
+    <system:String x:Key="NoModsActivatedLaunchingGameAsVanilla">没有开启任何模组。正在以“原版”模式启动游戏 ...</system:String>
+    <system:String x:Key="SelectedRendererIsNotSetToCustomLaunchingGameAsVanilla">选择的渲染器未设置为“自定义 J8 游戏驱动”。正在以“原版”模式启动游戏 ...</system:String>
+
+    <system:String x:Key="CreatingRuntimeProfile">正在创建 Runtime配置文件 ...</system:String>
+    <system:String x:Key="FailedToCreateRuntimeProfileForActiveMods">无法为已开启的模组创建Runtime配置文件 ...</system:String>
+
+    <system:String x:Key="VariableDumpSetToTrueStartingTurboLog">变量转储设置为 true。正在启动 TurBoLog ...</system:String>
+    <system:String x:Key="CopyingEasyHookToFf8PathIfNotFoundOrOlder">正在将 AppLoader.dll 复制到 FF8 目录（若未找到或检测到旧版本）...</system:String>
+
+    <system:String x:Key="CopyingFf8InputCfgToFf8Path">正在将 ff8input.cfg 复制到 FF8 目录 ...</system:String>
+    <system:String x:Key="DebugLoggingSetToTrueDetailedLoggingWillBeWrittenTo">调试日志设置为 true。详细日志将写入: </system:String>
+
+    <system:String x:Key="Found">已找到</system:String>
+
+    <system:String x:Key="LaunchingAdditionalProgramsToRunIfAny">正在启动要运行的附加程序 (如果有) ...</system:String>
+    <system:String x:Key="WritingTemporaryRuntimeProfileFileTo">正在将临时Runtime配置文件写入</system:String>
+
+    <system:String x:Key="AttemptingToInjectWithEasyHook">正在尝试通过 AppLoader 注入 ...</system:String>
+    <system:String x:Key="ReceivedErrors">收到报错</system:String>
+    <system:String x:Key="ReachedTimeoutWaitingForInjection">等待注入已超时 ...</system:String>
+    <system:String x:Key="ReceivedUnknownError">收到未知报错</system:String>
+    <system:String x:Key="FailedToInjectAfterMaxAmountOfTries">在最大尝试次数之后，仍然无法注入</system:String>
+
+    <system:String x:Key="ErrorFailedToStartGame">出错 - 游戏启动失败</system:String>
+    <system:String x:Key="FailedToInjectWithEasyHookMessage" xml:space="preserve">多次尝试之后，仍然无法通过 AppLoader 注入。通常的解决方法是在游戏启动器设置里将“Code 5 Fix”设置为“On”。
+
+是否要应用此设置并重试？</system:String>
+
+    <system:String x:Key="SettingCompatibilityFixAndTryingAgain">正在设置兼容性修复并重试 ...</system:String>
+    <system:String x:Key="StillFailedToInjectWithEasyHookAborting">设置兼容性修复后仍然无法通过 AppLoader 注入。正在中止 ...</system:String>
+    <system:String x:Key="FailedToInjectWithEasyHookAfterSettingFlags">即使设置了兼容性标志，仍然无法通过 AppLoader 注入</system:String>
+    <system:String x:Key="UserChoseNotToSetCompatibilityFix">用户选择不设置兼容性修复。正在中止 ...</system:String>
+
+    <system:String x:Key="GettingFf8Proc">正在获取 FF8 进程 ...</system:String>
+    <system:String x:Key="FailedToGetFf8Proc">获取 FF8 进程失败。正在中止 ...</system:String>
+    <system:String x:Key="DebugLoggingSetToTrueWiringUpLogFile">调试日志设置为 true。正在设置“日志文件在游戏退出后打开” ...</system:String>
+    <system:String x:Key="FailedToStartProcessForDebugLog">无法启动调试日志的进程</system:String>
+
+    <system:String x:Key="StartingProgramsForMods">正在启动模组所需程序 ...</system:String>
+    <system:String x:Key="StartingPluginsForMods">正在启动模组所需插件 ...</system:String>
+    <system:String x:Key="SettingUpFf8ExeToStopPluginsAndModPrograms">正在设置 FF8 .exe，以便在退出游戏后停止插件与模组程序 ...</system:String>
+
+    <system:String x:Key="StoppingOtherProgramsForMods">正在停止由 J8 启动的其它模组程序 ...</system:String>
+    <system:String x:Key="AutoUnmountingGameDisc">正在自动卸载游戏光盘 ...</system:String>
+
+    <system:String x:Key="WaitingForFf8ExeToRespond">正在等待 FF8 .exe 响应（最长 {0} 秒）...</system:String>
+    <system:String x:Key="ExceptionOccurredWhileTryingToStart">尝试启动 FF8 时发生异常 ...</system:String>
+
+    <system:String x:Key="PluginAdded">插件已添加</system:String>
+    <system:String x:Key="StartingPlugin">正在启动插件</system:String>
+
+    <system:String x:Key="FailedToGetListOfRuntimeMods">由于一个缺失的模组变量，无法获取 Runtime模组列表</system:String>
+    <system:String x:Key="AddingPathsToMonitor">正在添加需要读取的路径 ...</system:String>
+
+    <system:String x:Key="DetectedToBeOlderVersion">检测到是旧版本</system:String>
+    <system:String x:Key="Copied">已复制</system:String>
+    <system:String x:Key="SkippedCopying">已跳过复制</system:String>
+
+    <system:String x:Key="AnExceptionOccurredTryingToStartFf8At">尝试在以下路径启动 FF8 时发生异常：</system:String>
+
+    <system:String x:Key="ThereWasAnErrorVerifyingModConstraintSeeTheFollowingDetails">验证模组兼容规则时出错。详情如下:</system:String>
+    <system:String x:Key="TheFollowingSettingsHaveBeenChangedToMakeTheseModsCompatible">为了保证模组之间的兼容，以下设置已经自动调整:</system:String>
+
+
+    <system:String x:Key="ModRequiresYouToActivateAsWell">模组 {0} 需要同时开启 {1}</system:String>
+    <system:String x:Key="ModRequiresYouToActivateButYouDoNotHaveCompatibleVersionInstalled">模组 {0} 需要同时开启 {1}，但你并没有安装可以兼容的版本。尝试更新该模组？</system:String>
+    <system:String x:Key="UnsupportedModVersion">不支持的模组版本</system:String>
+
+    <system:String x:Key="IncompatibleMod">不兼容的模组</system:String>
+    <system:String x:Key="ModIsNotCompatibleWithTheVersionYouHaveInstalled">模组 {0} 不兼容你所安装的 {1} 的版本。尝试更新该模组？</system:String>
+    <system:String x:Key="ModIsNotCompatibleWithYouWillNeedToDisableIt">模组 {0} 不兼容 {1}。你需要禁用它。</system:String>
+    <system:String x:Key="ModIsNotCompatibleAnotherModVariableUsed">模组 {0} 不兼容 {1}，因为变量'{2}'在两个模组中同时存在。你需要禁用其中一个。</system:String>
+
+    <system:String x:Key="TheFollowingModsWillNotWorkProperlyInTheCurrentOrder">以下模组在当前加载顺序下无法正常使用。仍要继续吗？</system:String>
+    <system:String x:Key="LoadOrderIncompatible">加载顺序不兼容</system:String>
+    <system:String x:Key="ModIsMeantToComeBelowModInTheLoadOrder">模组 {0} 的加载顺序应该在 {1} 的下面。</system:String>
+    <system:String x:Key="ModIsMeantToComeAboveModInTheLoadOrder">模组 {0} 的加载顺序应该在 {1} 的上面。</system:String>
+
+    <system:String x:Key="CouldNotFindDdrawDllAt">ddraw.dll 无法在以下位置找到: </system:String>
+    <system:String x:Key="Renamed">已重命名</system:String>
+
+    <system:String x:Key="ApplyingChangedValuesToRegistry">正在将更改的值应用到注册表 ...</system:String>
+    <system:String x:Key="ApplyingCompatibilityFlagsInRegistry">正在应用注册表中的兼容性标志 (如果有) ...</system:String>
+    <system:String x:Key="CompatibilityFlagsFoundDeleting">找到了兼容性标志 - 正在删除</system:String>
+    <system:String x:Key="HighDpiFixSetToTrueApplyingCompatibilityFlag">高DPI修复设置为 true - 正在注册表中应用 HIGHDPIAWARE 兼容性标志</system:String>
+
+    <system:String x:Key="UsingControlConfigurationFile">正在使用按键配置文件</system:String>
+    <system:String x:Key="InputCfgFileNotFoundAt">在以下位置找不到按键配置.cfg文件: </system:String>
+    <system:String x:Key="FailedToCopyCfgFile">无法复制按键配置.cfg文件</system:String>
+
+    <system:String x:Key="StartingProgram">正在启动程序</system:String>
+    <system:String x:Key="Started">已启动 ...</system:String>
+    <system:String x:Key="WaitingForProgramToInitializeAndShow">正在等待程序初始化并显示 ...</system:String>
+    <system:String x:Key="TimeoutReachedWaitingForProgramToShow">等待程序显示超时 ({0}秒)。正在继续...</system:String>
+    <system:String x:Key="ProgramAlreadyRunning">程序已经正在运行</system:String>
+    
+    
+    
+    
+    <!--GameConverter Class Strings-->
+    <system:String x:Key="NotFoundScanningDiscsForFiles">未找到。正在扫描光盘以查找文件 ...</system:String>
+    <system:String x:Key="FoundFileOnAtCopyingFile">在 {0} 的 {1} 处找到文件。正在复制文件 ...</system:String>
+    <system:String x:Key="FailedToCopyErrorHasBeenLogged">复制失败。错误已记录</system:String>
+    <system:String x:Key="FailedToFindOnAnyDisc">无法在任何光盘上找到 {0} ...</system:String>
+    <system:String x:Key="FileNotFound">文件未找到...</system:String>
+    <system:String x:Key="FFNxTomlNotFoundRunGameFirst" xml:space="preserve">未找到 FFNx.toml 文件。\n\n请先至少运行一次游戏，然后再试。</system:String>
+    <system:String x:Key="CannotCopySourceFileBecauseItIsMissingAt">无法复制源文件，因为它在以下位置缺失: </system:String>
+    <system:String x:Key="CopyingFileFrom">正在从以下位置复制文件: </system:String>
+
+    <system:String x:Key="CannotCheckIfLatestDriverIsInstalledDueToMissingFile">由于文件缺失，无法检查是否安装了最新的驱动</system:String>
+    <system:String x:Key="GameDriverDllFileIsUpToDate">FFNx.dll文件是最新的。</system:String>
+    <system:String x:Key="BackingUpExistingGameDriverTo">正在将现有游戏驱动备份到</system:String>
+    <system:String x:Key="BackingUpExistingGameDriverCfgTo">正在将现有游戏驱动.cfg备份到</system:String>
+    <system:String x:Key="GameDriverCfgFileMissingCopyingDefaultFrom">FFNx.toml文件缺失。正在从以下位置复制默认文件: </system:String>
+    <system:String x:Key="CannotCreateDefaultCfgDueToMissingFile">由于文件缺失，无法创建默认.cfg</system:String>
+    <system:String x:Key="BackingUpExistingShadersFolderTo">正在将现有的“shaders”文件夹备份到</system:String>
+    <system:String x:Key="CopyingContentsOf">正在复制以下位置的内容: </system:String>
+    <system:String x:Key="DirectoryMissingCreating">文件夹缺失。正在创建</system:String>
+    <system:String x:Key="OldGameConverterRegistryKeysFoundBackingUp">找到了旧的游戏转换器注册表项。正在备份旧的转换器文件和注册表 ...</system:String>
+
+    <system:String x:Key="MissingShadersNolightFolderCreatingDirectory">缺少 shaders/nolight文件夹。正在创建 ...</system:String>
+    <system:String x:Key="MissingShadersComplexMultiShaderFolderCreatingDirectory">缺少 shaders/ComplexMultiShader_Nvidia文件夹。正在创建 ...</system:String>
+    <system:String x:Key="MissingShadersFolderCreatingDirectory">缺少 shaders 文件夹。正在从 Resources/Game Driver/ 复制 ...</system:String>
+    <system:String x:Key="MissingShadersFilesCopyingFrom">缺少着色器文件: {0}。正在从 {1} 复制 ...</system:String>
+    
+    
+    <!--UpdateChecker Class Strings-->
+    <system:String x:Key="CheckingForUpdatesUsingChannel">检查更新</system:String>
+    <system:String x:Key="FailedToCheckForUpdatesAt">检查更新失败</system:String>
+
+    
+    
+    <!--DEV NOTE TO REMOVE: STRINGS BELOW ADDED 4/5/20-->
+    <!--DEV NOTE TO REMOVE: STRINGS BELOW ADDED 4/5/20-->
+    <!--DEV NOTE TO REMOVE: STRINGS BELOW ADDED 4/5/20-->
+
+    <!--ConfigureGLWindow.xaml.cs Strings-->
+    <system:String x:Key="Graphics">画面</system:String>
+    <system:String x:Key="Controls">控制</system:String>
+    <system:String x:Key="Rendering">渲染</system:String>
+    <system:String x:Key="Cheats">快捷键</system:String>
+    <system:String x:Key="Advanced">高级</system:String>
+
+    <!--FileUtils.cs Strings-->
+    <system:String x:Key="FailedToCopyDirectory">复制到文件夹失败</system:String>
+    <system:String x:Key="FailedToMoveDirectory">移动到文件夹失败</system:String>
+    <system:String x:Key="FailedToDeleteFiles">文件删除失败</system:String>
+
+    <system:String x:Key="FailedToGetPreviewImage">预览图片获取失败</system:String>
+
+    <system:String x:Key="ErrorOccurredDownloadingInstalling">下载/安装时出错</system:String>
+
+    <system:String x:Key="Installed">已安装</system:String>
+    <system:String x:Key="Updated">已升级</system:String>
+    <system:String x:Key="ErrorUpdating">升级失败</system:String>
+
+    <system:String x:Key="FailedToGetModInfoDueToMissingVariable">警告: 由于缺少一个变量，导致无法获取模组信息，这可能会引发问题。</system:String>
+
+    <system:String x:Key="TheFollowingModsWereNotFoundInstalledAndHaveBeenRemoved">找不到以下模组的安装信息，已从配置文件中移除。</system:String>
+    <system:String x:Key="ErrorLoadingSettingsPleaseConfigureJ8">加载设置出错 —— 请通过“设置 → 常规设置...”菜单配置 J8</system:String>
+    <system:String x:Key="ErrorLoadingLibraryFile">无法加载存放模组的文件夹</system:String>
+    <system:String x:Key="FailedToImportMod">导入模组失败</system:String>
+    <system:String x:Key="AutoImportedMod">已自动导入模组</system:String>
+    <system:String x:Key="CouldNotImportIroFileIsCorrupt">.iroj 文件已损坏，无法导入，请重新下载。</system:String>
+    <system:String x:Key="ModCouldNotBeFoundHasItBeenDeleted">模组已丢失，请从列表中删除。</system:String>
+
+    <system:String x:Key="CouldNotLoadProfile">无法加载预设</system:String>
+
+    <system:String x:Key="FailedToPackIntoIro">打包 .iroj 失败</system:String>
+    <system:String x:Key="PackingIntoIro">正在将 {0} 打包成 .iroj ...</system:String>
+    <system:String x:Key="UnpackingIroIntoSubfolder">正在将 {0}.iroj 解包到 '{0}' 子文件夹 ...</system:String>
+    <system:String x:Key="FailedToUnpackIro">解包 .iroj 失败</system:String>
+
+    <system:String x:Key="SelectModToDownloadFirst">先选择一个要下载模组。</system:String>
+    <system:String x:Key="NoDownloadSelected">没有选择要下载的内容。</system:String>
+    <system:String x:Key="SelectAModFirst">先选择一个模组。</system:String>
+
+    <system:String x:Key="FailedToSaveCatalogXml">目录xml保存失败</system:String>
+
+    <system:String x:Key="ModNotActiveOnlyActivatedModsCanBeConfigured">模组未开启。先开启，再自定义配置。</system:String>
+
+    <system:String x:Key="UninstallWarning">卸载警告</system:String>
+    <system:String x:Key="AreYouSureYouWantToDelete">你确定要删除</system:String>
+    
+    
+    <!--ThemeSettingsWindow Strings-->
+    <system:String x:Key="ColorTheme">配色主题:</system:String>
+    <system:String x:Key="AppBackground">底层背景色:</system:String>
+    <system:String x:Key="SecondaryBackground">上层背景色:</system:String>
+    <system:String x:Key="ControlsDisabledBackground">二级按钮颜色:</system:String>
+    <system:String x:Key="ControlsDisabledForeground">二级字体颜色:</system:String>
+    <system:String x:Key="BackgroundImage">背景图片:</system:String>
+    <system:String x:Key="BackgroundHorizontalAlignment">背景图水平对齐:</system:String>
+    <system:String x:Key="BackgroundVerticalAlignment">背景图垂直对齐:</system:String>
+    <system:String x:Key="BackgroundStretch">背景图拉伸:</system:String>
+    <system:String x:Key="ControlsBackground">按钮颜色:</system:String>
+    <system:String x:Key="ControlsForeground">字体颜色:</system:String>
+    <system:String x:Key="ControlsSecondary">鼠标点击链接时的背景色:</system:String>
+    <system:String x:Key="ControlsMouseOver">鼠标滑过时的背景色:</system:String>
+    <system:String x:Key="ControlsPressed">所选内容的背景色:</system:String>
+    <system:String x:Key="ImportTheme">导入主题预设</system:String>
+
+
+
+    <!--PackIroUserControl Strings-->
+    <system:String x:Key="SourceFolder">源文件夹:</system:String>
+    <system:String x:Key="SaveAsIro">另存为IRO:</system:String>
+    <system:String x:Key="SaveAsIrop">另存为IROP:</system:String>
+    <system:String x:Key="Compress">压缩:</system:String>
+    <system:String x:Key="FilesToDelete">要删除的文件:</system:String>
+    <system:String x:Key="NewIro">新的IRO:</system:String>
+    <system:String x:Key="OriginalIro">原本的IRO:</system:String>
+    <system:String x:Key="SourceIro">IRO源文件:</system:String>
+
+    <!--CreateModUserControl Strings-->
+    <system:String x:Key="OutputsCurrentModXmlToBelow">将当前 mod.xml 输出到下方文本区域。</system:String>
+    <system:String x:Key="SaveModXmlToFile">保存 mod.xml文件</system:String>
+    <system:String x:Key="LoadModXmlFileToEdit">加载一个 mod.xml文件并进行编辑</system:String>
+
+    <system:String x:Key="GeneralSettingsTitle">常规设置</system:String>
+
+    <system:String x:Key="Greek">希腊语</system:String>
+
+    <!--DEV NOTE TO REMOVE: STRINGS BELOW ADDED 4/6/20-->
+    <!--DEV NOTE TO REMOVE: STRINGS BELOW ADDED 4/6/20-->
+    <system:String x:Key="ModSettingNoCompatibleOptionFoundTheFollowingModsRestrictIt">模组 {0}, 设置 {1} - 无法找到兼容选项。以下模组限制了它的配置方式:\n\n{2}</system:String>
+    <system:String x:Key="ModChangedSettingTo">模组 {0} - 已将设置 {1} 更改为 {2}</system:String>
+
+    <system:String x:Key="OutputsCurrentCatalogXmlToBelow">将当前 catalog.xml 输出到下方文本区域。</system:String>
+    <system:String x:Key="SaveCatalogXmlToFile">保存 catalog.xml文件</system:String>
+    <system:String x:Key="LoadCatalogXmlFileToEdit">加载一个 catalog.xml文件并进行编辑</system:String>
+    <system:String x:Key="AddModToCatalog">将模组添加到目录</system:String>
+    <system:String x:Key="ImportModFromModXmlOrIro">从 mod.xml 或 .iroj 导入模组</system:String>
+    <system:String x:Key="CatalogName">目录名称:</system:String>
+    <system:String x:Key="SaveCatalogXml">保存 catalog.xml</system:String>
+    <system:String x:Key="SelectCatalogXmlToLoad">选择要加载 catalog.xml</system:String>
+    <system:String x:Key="SelectModXmlOrIroFileToLoad">选择要加载的 mod.xml 或 .iroj 文件</system:String>
+    <system:String x:Key="SelectImageToUse">选择要使用的图片</system:String>
+    <system:String x:Key="SaveModXml">保存 mod.xml</system:String>
+    <system:String x:Key="SelectModXmlToLoad">选择要加载的 mod.xml</system:String>
+
+    <system:String x:Key="SaveAsIroTitle">将 .iroj 另存为</system:String>
+    <system:String x:Key="SaveAsIropTitle">将 .irojp 另存为</system:String>
+
+    <system:String x:Key="SelectTheFolderThatContainsAllTheModFiles">选择一个包含模组文件的文件夹，用于打包成IRO格式。</system:String>
+    <system:String x:Key="SelectFolderToOutputUnpackedFiles">选择一个文件夹，用于存放解包后的文件。</system:String>
+
+    <system:String x:Key="SelectFLevelLgpFile">选择 FLevel.lgp文件</system:String>
+
+    <system:String x:Key="GameLauncherSettings">游戏启动器设置</system:String>
+
+    <system:String x:Key="ClickToSelectFf8ExeFile">点击选择你的 FF8.exe 文件</system:String>
+    <system:String x:Key="ClickToSelectWhereYourMovieFolderIs">点击选择你电脑上的过场动画 movies文件夹</system:String>
+    <system:String x:Key="ClickToSelectWhereTexturesAreStored">点击选择你电脑上的外置贴图 Textures文件夹</system:String>
+    <system:String x:Key="ClickToSelectWhereYourModLibraryIs">点击选择你电脑上存放模组的文件夹</system:String>
+
+    <system:String x:Key="FF8ExeLabel">FF8 Exe：</system:String>
+    <system:String x:Key="MoviesLabel">过场动画 movies文件夹路径:</system:String>
+    <system:String x:Key="TexturesLabel">外置贴图 Textures文件夹路径:</system:String>
+    <system:String x:Key="LibraryLabel">存放模组的文件夹路径:</system:String>
+
+    <system:String x:Key="AddSubscriptionURL">添加订阅链接</system:String>
+    <system:String x:Key="RemoveSubscriptionURL">移除订阅链接</system:String>
+    <system:String x:Key="EditSubscriptionURL">编辑订阅链接/名称</system:String>
+    <system:String x:Key="MoveSubscriptionUp">向上移动订阅。右键点击移动到列表最上方。</system:String>
+    <system:String x:Key="MoveSubscriptionDown">向下移动订阅。右键点击移动到列表最下方。</system:String>
+
+    <system:String x:Key="AddFolder">添加文件夹</system:String>
+    <system:String x:Key="RemoveFolder">移除文件夹</system:String>
+    <system:String x:Key="MoveFolderUp">向上移动文件夹。右键点击移动到列表最上方。</system:String>
+    <system:String x:Key="MoveFolderDown">向下移动文件夹。右键点击移动到列表最下方。</system:String>
+    <system:String x:Key="EnterUrlInIrosFormat">通过 iroj:// 格式访问链接</system:String>
+
+    <system:String x:Key="SelectCustomThemeXmlFile">选择自定义主题的.xml文件</system:String>
+    <system:String x:Key="SaveCustomThemeXmlFile">保存自定义主题的.xml文件</system:String>
+    
+    <!--App Hints Strings-->
+    <system:String x:Key="AppHint1">你可以长按左键拖放模组，手动排列模组顺序。</system:String>
+    <system:String x:Key="AppHint2">你可以在任意已安装模组的标题上，单击鼠标中键，快速开启或禁用它。</system:String>
+    <system:String x:Key="AppHint3">你可以左键双击任意模组，快速打开自定义配置。</system:String>
+    <system:String x:Key="AppHint4">你可以左键双击“在线模组目录”界面的任意模组，快速下载使用它。</system:String>
+    <system:String x:Key="AppHint5">你可以点击右侧工具栏中的“自动排序”按钮，可以按照模组名称和及兼容规则，自动排列所有已安装的模组。</system:String>
+    <system:String x:Key="AppHint6">模组现在可以自动更新，或提醒你有新版本。</system:String>
+    <system:String x:Key="AppHint7">对于模组作者: 你可以将图片以base64编码的形式嵌入到你的Readme.html中。</system:String>
+    <system:String x:Key="AppHint8">对于模组作者: 你可以在 mod.xml 中使用“OrderConstraints”命令，自定义模组加载顺序。</system:String>
+    <system:String x:Key="AppHint9">对于模组作者: Junction VIII 现在支持树状图样式，方便修改模组配置。</system:String>
+    <system:String x:Key="AppHint10">对于模组作者: Junction VIII 现在支持使用 iroj://ExternalURL 外部链接格式，以便在浏览器中打开下载链接。</system:String>
+    <system:String x:Key="AppHint11">对于模组作者: 在“常规设置”中开启右键菜单选项，可以在 Windows 资源管理器中右键点击 .iroj 文件进行操作。</system:String>
+    <system:String x:Key="AppHint12">对于模组作者: 你可以将上传到在线模组目录中的 .iroj 文件，打包成 .7z/RAR/zip，Junction VIII 下载它们时会自动解压缩。</system:String>
+    <system:String x:Key="AppHint13">对于模组作者: 你可以通过编程的方式修改其它模组的配置，以确保它们兼容你的模组。</system:String>
+    <system:String x:Key="AppHint14">如果你将 .iroj 文件的打开方式设置为 JunctionVIII.exe，则可以在文件夹中双击 .iroj 文件，将模组快速导入 Junction VIII。</system:String>
+    <system:String x:Key="AppHint15">在“管理预设文件”界面，你可以左键双击一个预设文件，快速加载它。</system:String>
+    <system:String x:Key="AppHint16">打开“设置 → 预设”，选择一个预设文件，再点击上方眼睛图标，可以通过txt的方式查看预设参数。</system:String>
+    <system:String x:Key="AppHint17">Junction VIII 会记住你的模组自定义配置。当前模组禁用后再开启，不会丢失自定义配置。</system:String>
+    <system:String x:Key="AppHint18">点击“还原到初始状态”，可以恢复当前模组的默认配置。</system:String>
+    <system:String x:Key="AppHint19">不小心删除了订阅的在线模组目录链接？在“常规设置”里点击“还原默认”进行恢复。</system:String>
+    <system:String x:Key="AppHint20">右键点击“我的模组”选项，可以打开你存放模组的文件夹。</system:String>
+    <system:String x:Key="AppHint21">右键点击“在线模组目录”选项，可以打开在线模组订阅设置界面。</system:String>
+    <system:String x:Key="AppHint22">选中一个模组，右键点击右侧工具栏中的上/下箭头，可以将它移动到列表最上方/最下方。</system:String>
+    <system:String x:Key="AppHint23">模组排列顺序乱了？点击右侧工具栏中的“重置排序”按钮，自动排列所有已安装的模组。</system:String>
+    <system:String x:Key="AppHint24">在“我的模组”界面点击“类型”列中的▼，可以给未知类型“Unknown”的模组手动指定模组类型。</system:String>
+    <system:String x:Key="AppHint25">你可以前往Qhimm论坛 https://forums.qhimm.com 寻找疑难问题的解答。</system:String>
+    <system:String x:Key="AppHint26">你可以在“帮助”菜单里找到很多问题的解决方案。</system:String>
+    <system:String x:Key="AppHint27">打开“设置 → 游戏驱动”，可以修改游戏画面设置。</system:String>
+    <system:String x:Key="AppHint28">在左侧“模组信息”界面的“版本”中，点击▼可以选择模组更新需求（自动升级、提醒或忽略）。</system:String>
+    <system:String x:Key="AppHint29">Junction VIII 会自动挂载和卸载虚拟光驱。</system:String>
+    <system:String x:Key="AppHint30">Junction VIII 不再需要旧的游戏转换器。现已实现全面自动化！</system:String>
+    <system:String x:Key="AppHint31">你不需要再使用 FF8Config.exe。它的功能已经内置在“设置 → 游戏启动器”中。</system:String>
+    <system:String x:Key="AppHint32">你知道吗？Junction VIII 1.0 版本发布于 2013 年。而 2.0 发布于 7 年后的 2020 年。</system:String>
+    <system:String x:Key="AppHint33">当前加载的预设文件名称会显示在标题栏的方括号中。</system:String>
+    <system:String x:Key="AppHint34">游戏驱动现已内置高DPI支持。</system:String>
+    <system:String x:Key="AppHint35">你可以点击在线模组界面的“名称/类型/更新日期”等属性，对在线模组列表进行排列。</system:String>
+    <system:String x:Key="AppHint36">你可以直接长按鼠标左键，上下拖动模组名称，调整已安装模组的排列顺序。</system:String>
+    <system:String x:Key="AppHint37">您可以通过点击搜索框旁边的▼来筛选想要查看的模组类型。</system:String>
+    <system:String x:Key="AppHint38">打开“设置 → 键盘/手柄设置”，可以快速切换键盘/手柄预设。</system:String>
+    <system:String x:Key="AppHint39">你知道吗？Junction VIII 支持命令行参数（switches）。</system:String>
+    <system:String x:Key="AppHint40">如果你拥有 2000 版游戏光盘，则可以通过“过场动画导入工具”自动导入 movies 文件夹。</system:String>
+    <system:String x:Key="AppHint41">打开“设置 → 界面配色主题”，自定义你的 Junction VIII 界面颜色与背景图。</system:String>
+    <system:String x:Key="AppHint42">你可以导出自定义界面主题并分享给其他人。</system:String>
+    <system:String x:Key="AppHint43">你可以暂停和恢复部分下载。</system:String>
+
+    <system:String x:Key="ModManagerForFinalFantasy7">最终幻想VIII 模组管理器 ( 由 Tsunamods Team 维护 )</system:String>
+
+
+    <system:String x:Key="ReleaseDateLabel">发布日期:</system:String>
+    <system:String x:Key="ImageLinkLabel">图片链接:</system:String>
+    <system:String x:Key="InfoLinkLabel">信息链接:</system:String>
+    <system:String x:Key="DownloadLinksHeader" xml:space="preserve"> 下载链接 </system:String>
+    <system:String x:Key="AddLink">添加链接</system:String>
+
+    <system:String x:Key="MegaFolderID">Mega网盘ID:</system:String>
+
+    <system:String x:Key="Miscellaneous">模组设置及更新</system:String>
+    <system:String x:Key="Animations">动态资源</system:String>
+    <system:String x:Key="BattleModels">战斗模型</system:String>
+    <system:String x:Key="BattleTextures">战斗贴图</system:String>
+    <system:String x:Key="FieldModels">场景模型</system:String>
+    <system:String x:Key="FieldTextures">场景贴图</system:String>
+    <system:String x:Key="Gameplay">游戏玩法</system:String>
+    <system:String x:Key="Media">音视频</system:String>
+    <system:String x:Key="Minigames">小游戏</system:String>
+    <system:String x:Key="SpellTextures">魔法贴图</system:String>
+    <system:String x:Key="UserInterface">游戏界面</system:String>
+    <system:String x:Key="WorldModels">大地图模型</system:String>
+    <system:String x:Key="WorldTextures">大地图贴图</system:String>
+    <system:String x:Key="ModShaders">着色器</system:String>
+
+
+    <system:String x:Key="Cancelling">正在取消</system:String>
+
+    <system:String x:Key="Volume">音量</system:String>
+
+    <system:String x:Key="BrazilianPortuguese">巴西葡萄牙语</system:String>
+
+    
+    <!--DEV NOTE: STRINGS BELOW ADDED 4/29/20-->
+    <system:String x:Key="Italian">意大利语</system:String>
+
+    <system:String x:Key="SetInGameControls">设置游戏内的按键映射</system:String>
+    <system:String x:Key="Keyboard">键盘</system:String>
+    <system:String x:Key="Controller">手柄</system:String>
+    <system:String x:Key="ConfirmLabel">[确定 - OK]</system:String>
+    <system:String x:Key="CancelLabel">[取消 - CANCEL]</system:String>
+    <system:String x:Key="MenuLabel">[菜单 - MENU]</system:String>
+    <system:String x:Key="SwitchLabel">[卡片游戏 - CARDGAME]</system:String>
+    <system:String x:Key="ScrollUpLabel">[杂项 - MISC]</system:String>
+    <system:String x:Key="ScrollDownLabel">[射击 - TRIGGER]</system:String>
+
+    <system:String x:Key="CameraLabel">[向左旋转 - ROTLEFT]</system:String>
+    <system:String x:Key="TargetLabel">[向右旋转 - ROTRIGHT]</system:String>
+    <system:String x:Key="AssistLabel">[切换 - TOGGLE]</system:String>
+    <system:String x:Key="StartLabel">[暂停 - PAUSE]</system:String>
+
+    <system:String x:Key="UpLabel">[上 - UP]</system:String>
+    <system:String x:Key="DownLabel">[下 - DOWN]</system:String>
+    <system:String x:Key="LeftLabel">[左 - LEFT]</system:String>
+    <system:String x:Key="RightLabel">[右 - RIGHT]</system:String>
+
+    <system:String x:Key="Presets">按键预设:</system:String>
+    <system:String x:Key="EnablePS4ControllerSupport">启用PS4 XInput驱动</system:String>
+    <system:String x:Key="PS4ControllerSupportTooltip">允许使用PS4手柄作为XInput设备，并通过触摸板控制鼠标 (需要安装SCP驱动)</system:String>
+    <system:String x:Key="SaveChangesTooltip">保存控制器设置</system:String>
+
+    <system:String x:Key="OpenGameControllersWindow">打开游戏控制器窗口</system:String>
+    
+    <system:String x:Key="ControlsTooltip">选择一个预设，然后点击“关闭”即可。</system:String>
+
+
+    <system:String x:Key="StartingPS4ControllerService">启动PS4手柄服务 ...</system:String>
+    <system:String x:Key="ServiceAlreadyRunning">服务已运行 ...</system:String>
+
+    <system:String x:Key="RetryInstallTooltip">重新尝试安装模组</system:String>
+
+
+    <system:String x:Key="MovieImporter">过场动画导入工具...</system:String>
+    <system:String x:Key="AllMovieFilesAlreadyImported" xml:space="preserve">所有过场动画都已经导入！</system:String>
+
+    <system:String x:Key="ImportMoviesFromDisc">从光盘导入 movies文件夹里的过场动画</system:String>
+
+    <system:String x:Key="EnableTriggerDpadSupport">模拟DInput设备的方向键</system:String>
+    <system:String x:Key="TriggerDpadSupportTooltip">使用键盘来模拟游戏内的方向键 (如果你使用 XInput 手柄，则不要选择此项)</system:String>
+
+    <system:String x:Key="MountDiscWithPowershell">通过 PowerShell 加载</system:String>
+    <system:String x:Key="MountDiscWithWinCDEmu">通过 WinCDEmu 加载</system:String>
+    <system:String x:Key="DoNotMount">不加载虚拟光驱</system:String>
+
+    <system:String x:Key="LoadingDevices">加载设备 ...</system:String>
+
+    <system:String x:Key="MountOptionToolTip">选择加载虚拟光驱（FF8DISC1）的方式。Windows 7 系统只能使用 '通过 WinCDEmu 加载' 的选项。</system:String>
+
+    <system:String x:Key="ControlsMenuItemText">键盘/手柄设置...</system:String>
+    
+    <system:String x:Key="SaveControlsPreset">你需要将当前的结果保存为新的配置文件，请为配置文件起一个名字（中文/英文都可以）:</system:String>
+
+    <!--DEV NOTE: STRINGS BELOW ADDED 7/11/20-->
+    <system:String x:Key="VerifyingEnglishGameFilesExist">正在验证英语版游戏文件是否存在 ...</system:String>
+    <system:String x:Key="FoundLanguageInstalledCreatingEnglishGameFiles">找到安装的语言: {0} 正在创建英语版游戏文件...</system:String>
+    <system:String x:Key="ErrorOnlyEnglishLanguageSupported">错误：仅支持英语原版游戏本体。请确保你的游戏本体是 FF8 Steam 英文原版。</system:String>
+    <system:String x:Key="ExtractingLGPFiles">正在提取.lgp文件 ...</system:String>
+    <system:String x:Key="RenamingLanguageSpecificFiles">重命名特定语言的文件 ...</system:String>
+    <system:String x:Key="CouldNotFindFileToRename">无法找到要重命名的文件: {0} ...</system:String>
+    <system:String x:Key="EncodingNewLGPFiles">正在为新的.lgp文件进行编码 ...</system:String>
+    <system:String x:Key="DeletingTemporaryFiles">删除临时文件 ...</system:String>
+    <system:String x:Key="BeginningToPollForGamePadInput">开始加载游戏手柄映射设置 ...</system:String>
+    <system:String x:Key="WaitingForFF8WindowToBeVisible">正在等待 FF8 窗口显示（最长 {0} 秒）...</system:String>
+    <system:String x:Key="CouldNotFindFileToCopy">无法找到要复制的文件: {0} ...</system:String>
+    <system:String x:Key="AnErrorOccurredStartingULGP">启动 ulgp.exe 时出现错误</system:String>
+    <system:String x:Key="UpdatingPathsInSysSettings">使用新的安装路径更新“Sys.Settings”中的路径设置</system:String>
+    <system:String x:Key="ForceMinimizingProgram">强制最小化程序 ...</system:String>
+    <system:String x:Key="FailedToStartAdditionalProgram">无法启动附加程序: {0}</system:String>
+
+    <system:String x:Key="CanaryWarningTitle">使用必读！</system:String>
+    <system:String x:Key="CanaryWarningMessage">感谢您选择使用“开发版”。\n\n这个版本适用于有一定动手能力的玩家，方便支持开发和反馈bug。如果你希望拥有稳定的游戏体验，请勿使用开发版。</system:String>
+
+    <system:String x:Key="PleaseUpdateFFNx">无法加载游戏根目录下的 FFNx.toml文件。你的FFNx版本可能已经过时。请尝试将FFNx升级到最新版本。</system:String>
+
+    <system:String x:Key="CheckForSystemDEPStatus">检查系统 DEP状态...</system:String>
+    <system:String x:Key="DEPDetected">检测到 DEP</system:String>
+    <system:String x:Key="DoYouWantToDisableDEP">你需要为自己的电脑设置“仅为基本的 Windows 程序和服务启用 DEP”，点击“是”自动调整。</system:String>
+    <system:String x:Key="SystemDEPDisabledPleaseReboot">DEP模式调整成功，请重启电脑。</system:String>
+    <system:String x:Key="CannotContinueWithDEPEnabled">DEP 模式不正确，请参照这里的方法手动调整: https://JunctionVIII.rocks/help/dep.html</system:String>
+    <system:String x:Key="SomethingWentWrongWhileDisablingDEP">DEP 模式调整失败，请参照这里的方法手动调整: https://JunctionVIII.rocks/help/dep.html</system:String>
+
+    <system:String x:Key="App4GBPatchRequired">确保游戏 exe 应用了4GB补丁..</system:String>
+    <system:String x:Key="App4GBPatchApplied">4GB补丁应用成功。</system:String>
+
+    <system:String x:Key="OpenSaveGamePath">打开游戏存档文件夹...</system:String>
+</ResourceDictionary>

--- a/AppUI/Resources/StringResources.xaml
+++ b/AppUI/Resources/StringResources.xaml
@@ -1181,6 +1181,8 @@ Do you want to apply the setting and try again?</system:String>
     <!--DEV NOTE: STRINGS BELOW ADDED 4/29/20-->
     <system:String x:Key="Italian">Italian</system:String>
 
+    <system:String x:Key="SimplifiedChinese">Simplified Chinese</system:String>
+
     <system:String x:Key="SetInGameControls">Set In-Game Controls</system:String>
     <system:String x:Key="Keyboard">Keyboard</system:String>
     <system:String x:Key="Controller">Controller</system:String>

--- a/AppUI/ViewModels/SetLanguageViewModel.cs
+++ b/AppUI/ViewModels/SetLanguageViewModel.cs
@@ -62,6 +62,7 @@ namespace AppUI.ViewModels
             LanguagesMap.Add($"{ResourceHelper.Get(StringKey.Greek)} (Ελληνικά)", "gr");
             LanguagesMap.Add($"{ResourceHelper.Get(StringKey.Italian)} (Italiano)", "it");
             LanguagesMap.Add($"{ResourceHelper.Get(StringKey.Spanish)} (Español)", "es");
+            LanguagesMap.Add($"{ResourceHelper.Get(StringKey.SimplifiedChinese)} (\u7b80\u4f53\u4e2d\u6587)", "zh");
             //LanguagesMap.Add($"{ResourceHelper.Get(StringKey.Japanese)} (\u65e5\u672c\u8a9e)", "ja");
 
 


### PR DESCRIPTION
Based on the style and terminology of 7th Heaven's Chinese translation, add Simplified Chinese translation for Junction VIII.

P.S. Thanks to the Junction VIII and FFNx development teams for adding support to FF8R, which made it possible for our unofficial FF8R Chinese translation project to realize Chinese voiceover!

<img width="1920" height="1080" alt="FF高清计划片头 mp4_000012 633" src="https://github.com/user-attachments/assets/4cc66f3f-235a-4f84-9f5c-aabd5abbc83c" />
